### PR TITLE
Reads requests headers and bodies

### DIFF
--- a/src/main/java/ClientSocket.java
+++ b/src/main/java/ClientSocket.java
@@ -34,7 +34,7 @@ class ClientSocket implements HttpSocket {
     public void setHttpResponse(HttpResponse httpResponse) {
         System.out.println("Returning a response!");
         try {
-            socket.getOutputStream().write(responseFormatter.format(httpResponse));//.formatForClient());
+            socket.getOutputStream().write(responseFormatter.format(httpResponse));
         } catch (IOException e) {
             throw new ClientSocketException("Exception whilst writing request to socket", e);
         }

--- a/src/main/java/ClientSocket.java
+++ b/src/main/java/ClientSocket.java
@@ -5,9 +5,11 @@ import java.net.Socket;
 class ClientSocket implements HttpSocket {
 
     private final Socket socket;
+    private ResponseFormatter responseFormatter;
 
-    public ClientSocket(Socket socket) {
+    public ClientSocket(Socket socket, ResponseFormatter responseFormatter) {
         this.socket = socket;
+        this.responseFormatter = responseFormatter;
     }
 
     @Override
@@ -32,7 +34,7 @@ class ClientSocket implements HttpSocket {
     public void setHttpResponse(HttpResponse httpResponse) {
         System.out.println("Returning a response!");
         try {
-            socket.getOutputStream().write(httpResponse.formatForClient());
+            socket.getOutputStream().write(responseFormatter.format(httpResponse));//.formatForClient());
         } catch (IOException e) {
             throw new ClientSocketException("Exception whilst writing request to socket", e);
         }

--- a/src/main/java/HttpMethods.java
+++ b/src/main/java/HttpMethods.java
@@ -1,0 +1,7 @@
+public enum HttpMethods {
+    GET,
+    HEAD,
+    OPTIONS,
+    POST,
+    PUT
+}

--- a/src/main/java/HttpRequest.java
+++ b/src/main/java/HttpRequest.java
@@ -7,7 +7,10 @@ public class HttpRequest {
     private Map<String, String> headerParams;
     private String body;
 
-    public HttpRequest(String method, String requestUri, Map<String, String> headerParams, String bodyContent) {
+    public HttpRequest(String method,
+                       String requestUri,
+                       Map<String, String> headerParams,
+                       String bodyContent) {
         this.method = method;
         this.requestUri = requestUri;
         this.headerParams = headerParams;

--- a/src/main/java/HttpRequest.java
+++ b/src/main/java/HttpRequest.java
@@ -1,11 +1,17 @@
+import java.util.Map;
+
 public class HttpRequest {
 
     private final String method;
     private String requestUri;
+    private Map<String, String> headerParams;
+    private String body;
 
-    public HttpRequest(String method, String requestUri) {
+    public HttpRequest(String method, String requestUri, Map<String, String> headerParams, String bodyContent) {
         this.method = method;
         this.requestUri = requestUri;
+        this.headerParams = headerParams;
+        this.body = bodyContent;
     }
 
     public String getMethod() {
@@ -14,6 +20,14 @@ public class HttpRequest {
 
     public String getRequestUri() {
         return requestUri;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public Map<String, String> headerParameters() {
+        return headerParams;
     }
 }
 

--- a/src/main/java/HttpRequest.java
+++ b/src/main/java/HttpRequest.java
@@ -7,7 +7,7 @@ public class HttpRequest {
     private Map<String, String> headerParams;
     private String body;
 
-    public HttpRequest(String method,
+    protected HttpRequest(String method,
                        String requestUri,
                        Map<String, String> headerParams,
                        String bodyContent) {

--- a/src/main/java/HttpRequestBuilder.java
+++ b/src/main/java/HttpRequestBuilder.java
@@ -21,7 +21,7 @@ public class HttpRequestBuilder {
         return this;
     }
 
-    public HttpRequestBuilder withHeaderParamters(Map<String, String> headerParams) {
+    public HttpRequestBuilder withHeaderParameters(Map<String, String> headerParams) {
         this.headerParameters = headerParams;
         return this;
     }

--- a/src/main/java/HttpRequestBuilder.java
+++ b/src/main/java/HttpRequestBuilder.java
@@ -1,0 +1,37 @@
+import java.util.Map;
+
+public class HttpRequestBuilder {
+
+    private String requestLine;
+    private String requestUri;
+    private Map<String, String> headerParameters;
+    private String body;
+
+    public static HttpRequestBuilder anHttpRequestBuilder() {
+        return new HttpRequestBuilder();
+    }
+
+    public HttpRequestBuilder withRequestLine(String requestLine) {
+        this.requestLine = requestLine;
+        return this;
+    }
+
+    public HttpRequestBuilder withRequestUri(String uri) {
+        this.requestUri = uri;
+        return this;
+    }
+
+    public HttpRequestBuilder withHeaderParamters(Map<String, String> headerParams) {
+        this.headerParameters = headerParams;
+        return this;
+    }
+
+    public HttpRequestBuilder withBody(String body) {
+        this.body = body;
+        return this;
+    }
+
+    public HttpRequest build() {
+       return new HttpRequest(requestLine, requestUri, headerParameters, body);
+    }
+}

--- a/src/main/java/HttpRequestParser.java
+++ b/src/main/java/HttpRequestParser.java
@@ -29,7 +29,7 @@ public class HttpRequestParser implements RequestParser {
         return HttpRequestBuilder.anHttpRequestBuilder()
                 .withRequestLine(getMethod(requestLine))
                 .withRequestUri(getRequestUri(requestLine))
-                .withHeaderParamters(headerParams)
+                .withHeaderParameters(headerParams)
                 .withBody(String.valueOf(bodyContents))
                 .build();
     }

--- a/src/main/java/HttpRequestParser.java
+++ b/src/main/java/HttpRequestParser.java
@@ -34,24 +34,17 @@ public class HttpRequestParser implements RequestParser {
                 .build();
     }
 
-    private char[] getBody(BufferedReader reader, int contentLength) throws IOException {
-        char[] bodyContents = new char[contentLength];
-        reader.read(bodyContents, 0, contentLength);
-        return bodyContents;
-    }
-
-    private int getContentLength(Map<String, String> headerParams) {
-        String contentLengthFromHeader = headerParams.get("Content-Length");
-        return contentLengthFromHeader != null ? Integer.valueOf(contentLengthFromHeader) : 0;
-    }
-
     private String[] getRequestLine(BufferedReader reader) throws IOException {
         String firstLine = readLine(reader);
         return split(firstLine, space());
     }
 
-    private String[] split(String line, String delimeter) {
-        return line.split(delimeter);
+    private String getRequestUri(String[] requestLine) {
+        return requestLine[1];
+    }
+
+    private String getMethod(String[] requestLine) {
+        return requestLine[0];
     }
 
     private Map<String, String> getHeaderParameters(BufferedReader reader) throws IOException {
@@ -76,23 +69,30 @@ public class HttpRequestParser implements RequestParser {
         return params[1].trim();
     }
 
-    private boolean hasContent(String headerLine) {
-        return !headerLine.isEmpty();
-    }
-
-    private String getRequestUri(String[] requestLine) {
-        return requestLine[1];
-    }
-
-    private String getMethod(String[] requestLine) {
-        return requestLine[0];
-    }
-
-    private String space() {
-        return " ";
+    private char[] getBody(BufferedReader reader, int contentLength) throws IOException {
+        char[] bodyContents = new char[contentLength];
+        reader.read(bodyContents, 0, contentLength);
+        return bodyContents;
     }
 
     private String readLine(BufferedReader reader) throws IOException {
         return reader.readLine();
+    }
+
+    private String[] split(String line, String delimeter) {
+        return line.split(delimeter);
+    }
+
+    private boolean hasContent(String headerLine) {
+        return !headerLine.isEmpty();
+    }
+
+    private int getContentLength(Map<String, String> headerParams) {
+        String contentLengthFromHeader = headerParams.get("Content-Length");
+        return contentLengthFromHeader != null ? Integer.valueOf(contentLengthFromHeader) : 0;
+    }
+
+    private String space() {
+        return " ";
     }
 }

--- a/src/main/java/HttpRequestParser.java
+++ b/src/main/java/HttpRequestParser.java
@@ -2,6 +2,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
 
 public class HttpRequestParser implements RequestParser {
     @Override
@@ -12,12 +14,54 @@ public class HttpRequestParser implements RequestParser {
 
     protected HttpRequest parseRequest(BufferedReader reader) {
         String[] requestLine;
+
         try {
-            requestLine = parseRequestLine(readLine(reader));
-            return new HttpRequest(getMethod(requestLine), getRequestUri(requestLine));
+            requestLine = getRequestLine(reader);
+            Map<String, String> headerParams = getHeaderParameters(reader);
+            char[] bodyContents = getBody(reader, getContentLength(headerParams));
+
+            //TODO maybe should be a builder aswell
+            return new HttpRequest(getMethod(requestLine), getRequestUri(requestLine), headerParams, String.valueOf(bodyContents));
         } catch (IOException e) {
             throw new HttpRequestParsingException("Error in parsing Http Request", e);
         }
+    }
+
+    private char[] getBody(BufferedReader reader, int contentLength) throws IOException {
+        char[] bodyContents = new char[contentLength];
+        reader.read(bodyContents, 0, contentLength);
+        System.out.println("body is: " + String.valueOf(bodyContents));
+        return bodyContents;
+    }
+
+    private int getContentLength(Map<String, String> headerParams) {
+        String contentLengthFromHeader = headerParams.get("Content-Length");
+        return contentLengthFromHeader != null ? Integer.valueOf(contentLengthFromHeader) : 0;
+    }
+
+    private String[] getRequestLine(BufferedReader reader) throws IOException {
+        String[] requestLine;
+        String firstLine = readLine(reader);
+        requestLine = parseRequestLine(firstLine);
+        return requestLine;
+    }
+
+    private Map<String, String> getHeaderParameters(BufferedReader reader) throws IOException {
+        Map<String, String> headerParams = new HashMap<>();
+
+        String headerLine = readLine(reader);
+        while (!headerLine.isEmpty()) {
+            String[] mapEntry = headerLine.split(":");
+            System.out.println("make into a map" + mapEntry[0].trim() + " => " + mapEntry[1].trim());
+            headerParams.put(mapEntry[0].trim(), mapEntry[1].trim());
+            headerLine = readLine(reader);
+        }
+
+//        if (headerParams.get("Content-Length") == null) {
+//            headerParams.put("Content-Length", "0");
+//        }
+
+        return headerParams;
     }
 
     private String[] parseRequestLine(String line) {
@@ -39,4 +83,5 @@ public class HttpRequestParser implements RequestParser {
     private String readLine(BufferedReader reader) throws IOException {
         return reader.readLine();
     }
+
 }

--- a/src/main/java/HttpRequestProcessor.java
+++ b/src/main/java/HttpRequestProcessor.java
@@ -1,4 +1,8 @@
 public class HttpRequestProcessor implements RequestProcessor {
+
+    public HttpRequestProcessor() {
+    }
+
     @Override
     public HttpResponse process(HttpRequest httpRequest) {
         HttpResponseBuilder httpResponseBuilder = HttpResponseBuilder.anHttpResponseBuilder();
@@ -14,6 +18,7 @@ public class HttpRequestProcessor implements RequestProcessor {
         else {
            httpResponseBuilder.withStatus(404).withReasonPhrase("Not Found");
         }
+
         return httpResponseBuilder.build();
     }
 }

--- a/src/main/java/HttpRequestProcessor.java
+++ b/src/main/java/HttpRequestProcessor.java
@@ -13,7 +13,7 @@ public class HttpRequestProcessor implements RequestProcessor {
             httpResponseBuilder.withStatus(200).withReasonPhrase("OK");
         }
         else if (httpRequest.getRequestUri().equals("/method_options")) {
-          httpResponseBuilder.withStatus(200).withReasonPhrase("OK").withAllowMethods("GET", "HEAD", "POST", "OPTIONS", "PUT");
+          httpResponseBuilder.withStatus(200).withReasonPhrase("OK").withAllowMethods(HttpMethods.values());
         }
         else {
            httpResponseBuilder.withStatus(404).withReasonPhrase("Not Found");

--- a/src/main/java/HttpResponse.java
+++ b/src/main/java/HttpResponse.java
@@ -3,14 +3,14 @@ import java.util.List;
 
 class HttpResponse {
     private final int statusCode;
-    private final List<String> allowedMethods;
+    private final List<HttpMethods> allowedMethods;
     private String httpVersion;
     private String reasonPhrase;
 
     protected HttpResponse(int statusCode,
                            String httpVersion,
                            String reasonPhrase,
-                           List<String> allowedMethods) {
+                           List<HttpMethods> allowedMethods) {
         this.statusCode = statusCode;
         this.httpVersion = httpVersion;
         this.reasonPhrase = reasonPhrase;
@@ -29,7 +29,7 @@ class HttpResponse {
         return reasonPhrase;
     }
 
-    public List<String> allowedMethods() {
+    public List<HttpMethods> allowedMethods() {
         return allowedMethods;
     }
 }

--- a/src/main/java/HttpResponse.java
+++ b/src/main/java/HttpResponse.java
@@ -1,4 +1,3 @@
-import java.io.UnsupportedEncodingException;
 import java.util.List;
 
 
@@ -8,46 +7,14 @@ class HttpResponse {
     private String httpVersion;
     private String reasonPhrase;
 
-    protected HttpResponse(int statusCode, String httpVersion, String reasonPhrase, List<String> allowedMethods) {
+    protected HttpResponse(int statusCode,
+                           String httpVersion,
+                           String reasonPhrase,
+                           List<String> allowedMethods) {
         this.statusCode = statusCode;
         this.httpVersion = httpVersion;
         this.reasonPhrase = reasonPhrase;
         this.allowedMethods = allowedMethods;
-    }
-
-    public byte[] formatForClient() {
-        try {
-            return formatResponse();
-        } catch (UnsupportedEncodingException e) {
-            throw new HttpResponseException("Error in creating HTTP Response", e);
-        }
-    }
-
-    protected byte[] formatResponse() throws UnsupportedEncodingException {
-        String formattedResponse = statusLine();
-
-        if (allowedMethods.size() > 0) {
-            String allowedLine = "";
-            String firstMethod = allowedMethods.get(0);
-            for (int i = 1; i < allowedMethods().size(); i++) {
-                allowedLine += "," + allowedMethods.get(i);
-            }
-            formattedResponse = formattedResponse + "\r\nAllow: " + firstMethod + allowedLine;
-        }
-        System.out.println("formatted response is  " + formattedResponse);
-        return (formattedResponse + endOfStatusLine()).getBytes("UTF-8");
-    }
-
-    private String statusLine() {
-        return httpVersion + space() + statusCode + space() + reasonPhrase;
-    }
-
-    private String endOfStatusLine() {
-        return "\r\n\r\n";
-    }
-
-    private String space() {
-        return " ";
     }
 
     public int statusCode() {

--- a/src/main/java/HttpResponseBuilder.java
+++ b/src/main/java/HttpResponseBuilder.java
@@ -3,17 +3,16 @@ import java.util.Collections;
 import java.util.List;
 
 public final class HttpResponseBuilder {
-    private String httpVersion = "HTTP/1.1";
     private int statusCode;
     private String reasonPhrase;
-    private List<String> allowedMethods = new ArrayList<>();
+    private List<HttpMethods> allowedMethods = new ArrayList<>();
 
     public static HttpResponseBuilder anHttpResponseBuilder() {
         return new HttpResponseBuilder();
     }
 
     public HttpResponse build() {
-        return new HttpResponse(statusCode, httpVersion, reasonPhrase, allowedMethods);
+        return new HttpResponse(statusCode, "HTTP/1.1", reasonPhrase, allowedMethods);
     }
 
     public HttpResponseBuilder withStatus(int statusCode) {
@@ -26,7 +25,7 @@ public final class HttpResponseBuilder {
         return this;
     }
 
-    public HttpResponseBuilder withAllowMethods(String... supportedMethods) {
+    public HttpResponseBuilder withAllowMethods(HttpMethods... supportedMethods) {
         Collections.addAll(allowedMethods, supportedMethods);
         return this;
     }

--- a/src/main/java/HttpResponseFormatter.java
+++ b/src/main/java/HttpResponseFormatter.java
@@ -1,0 +1,64 @@
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+
+public class HttpResponseFormatter implements ResponseFormatter {
+    @Override
+    public byte[] format(HttpResponse response) {
+        try {
+            return createFormatted(response);
+        } catch (UnsupportedEncodingException e) {
+            throw new HttpResponseException("Error in creating HTTP Response", e);
+        }
+    }
+
+    protected byte[] createFormatted(HttpResponse response) throws UnsupportedEncodingException {
+        String formattedHeader = formatStatusLine(response);
+        if (hasAllowMethods(response)) {
+            formattedHeader += addAllowLineToHeader(response);
+        }
+        formattedHeader += endOfHeader();
+
+        System.out.println("formatted response is  " + formattedHeader);
+        return formattedHeader.getBytes("UTF-8");
+    }
+
+    private String addAllowLineToHeader(HttpResponse response)  {
+        return endOfLine() + commaDelimitAllowParameters(response);
+    }
+
+    private boolean hasAllowMethods(HttpResponse response) {
+        return response.allowedMethods().size() > 0;
+    }
+
+    private String commaDelimitAllowParameters(HttpResponse response) { //String formattedResponse) {
+        List<String> allowMethods = response.allowedMethods();
+        String allowedLine = "";
+        String firstMethod = "";
+        if (allowMethods.size() > 0) {
+            firstMethod = allowMethods.get(0);
+            for (int i = 1; i < allowMethods.size(); i++) {
+                allowedLine += "," + allowMethods.get(i);
+            }
+            return "Allow: " + firstMethod + allowedLine;
+        }
+        return "";
+    }
+
+    private String formatStatusLine(HttpResponse response) {
+        return response.httpVersion() + space()
+                + response.statusCode() + space()
+                + response.reasonPhrase();
+    }
+
+    private String endOfHeader() {
+        return endOfLine() + endOfLine();
+    }
+
+    private String endOfLine() {
+        return "\r\n";
+    }
+
+    private String space() {
+        return " ";
+    }
+}

--- a/src/main/java/HttpResponseFormatter.java
+++ b/src/main/java/HttpResponseFormatter.java
@@ -30,10 +30,10 @@ public class HttpResponseFormatter implements ResponseFormatter {
         return response.allowedMethods().size() > 0;
     }
 
-    private String commaDelimitAllowParameters(HttpResponse response) { //String formattedResponse) {
-        List<String> allowMethods = response.allowedMethods();
+    private String commaDelimitAllowParameters(HttpResponse response) {
+        List<HttpMethods> allowMethods = response.allowedMethods();
         String allowedLine = "";
-        String firstMethod = "";
+        HttpMethods firstMethod;
         if (allowMethods.size() > 0) {
             firstMethod = allowMethods.get(0);
             for (int i = 1; i < allowMethods.size(); i++) {
@@ -41,7 +41,7 @@ public class HttpResponseFormatter implements ResponseFormatter {
             }
             return "Allow: " + firstMethod + allowedLine;
         }
-        return "";
+        return allowedLine;
     }
 
     private String formatStatusLine(HttpResponse response) {

--- a/src/main/java/HttpServer.java
+++ b/src/main/java/HttpServer.java
@@ -30,9 +30,7 @@ public class HttpServer {
         HttpSocket client = serverSocket.accept();
         HttpRequest httpRequest = requestParser.parse(client.getRawHttpRequest());
 
-        HttpResponse httpResponse = httpRequestProcessor.process(httpRequest);
-
-        client.setHttpResponse(httpResponse);
+        client.setHttpResponse(httpRequestProcessor.process(httpRequest));
         client.close();
     }
 }

--- a/src/main/java/HttpServerRunner.java
+++ b/src/main/java/HttpServerRunner.java
@@ -9,9 +9,17 @@ public class HttpServerRunner {
         String host = "localhost";
         int port = commandLineArgumentParser.extractPort(args);
         String publicDirectory = commandLineArgumentParser.extractPublicDirectory(args);
-        HttpServerSocket httpServerSocket = new HttpServerSocket(new ServerSocket(port));
 
-        HttpServer httpServer = new HttpServer(host, port, httpServerSocket, new HttpRequestParser(), new HttpRequestProcessor());
+        HttpServerSocket httpServerSocket = new HttpServerSocket(new ServerSocket(port), new HttpResponseFormatter());
+
+        HttpServer httpServer = new HttpServer(
+                host,
+                port,
+                httpServerSocket,
+                new HttpRequestParser(),
+                new HttpRequestProcessor()
+        );
+
         start(httpServer);
     }
 

--- a/src/main/java/HttpServerSocket.java
+++ b/src/main/java/HttpServerSocket.java
@@ -3,14 +3,16 @@ import java.net.ServerSocket;
 
 public class HttpServerSocket {
     private final ServerSocket serverSocket;
+    private ResponseFormatter responseFormatter;
 
-    public HttpServerSocket(ServerSocket serverSocket) {
+    public HttpServerSocket(ServerSocket serverSocket, ResponseFormatter httpResponseFormatter) {
        this.serverSocket = serverSocket;
+        responseFormatter = httpResponseFormatter;
     }
 
     public HttpSocket accept() {
         try {
-            return new ClientSocket(serverSocket.accept());
+            return new ClientSocket(serverSocket.accept(), responseFormatter);
         } catch (IOException e) {
             throw new HttpServerSocketException("Exception occurred whilst server was accepting client requests", e);
         }

--- a/src/main/java/ResponseFormatter.java
+++ b/src/main/java/ResponseFormatter.java
@@ -1,0 +1,4 @@
+
+public interface ResponseFormatter {
+    byte[] format(HttpResponse response);
+}

--- a/src/test/java/ClientSocketTest.java
+++ b/src/test/java/ClientSocketTest.java
@@ -10,7 +10,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
 
-import static java.util.Collections.EMPTY_LIST;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -62,7 +61,10 @@ public class ClientSocketTest {
 
         ClientSocket clientSocket = new ClientSocket(fakeSocket(), responseFormatterSpy);
 
-        clientSocket.setHttpResponse(new HttpResponse(200, "HTTP/1.1", "OK", EMPTY_LIST));
+        clientSocket.setHttpResponse(HttpResponseBuilder.anHttpResponseBuilder()
+                .withStatus(200)
+                .withReasonPhrase("OK")
+                .build());
 
         assertThat(responseFormatterSpy.hasFormatted(), is(true));
     }
@@ -87,19 +89,19 @@ public class ClientSocketTest {
 
     private Socket fakeSocket() {
         return new Socket() {
-                @Override
-                public InputStream getInputStream() throws IOException {
-                    throw new RuntimeException("Not implemented for test");
-                }
+            @Override
+            public InputStream getInputStream() throws IOException {
+                throw new RuntimeException("Not implemented for test");
+            }
 
-                public synchronized void close() throws IOException {
-                    throw new RuntimeException("Not implemented for test");
-                }
+            public synchronized void close() throws IOException {
+                throw new RuntimeException("Not implemented for test");
+            }
 
-                public OutputStream getOutputStream() throws IOException {
-                    return new ByteArrayOutputStream(10);
-                }
-            };
+            public OutputStream getOutputStream() throws IOException {
+                return new ByteArrayOutputStream(10);
+            }
+        };
     }
 }
 

--- a/src/test/java/ClientSocketTest.java
+++ b/src/test/java/ClientSocketTest.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
-import java.util.Collections;
 
 public class ClientSocketTest {
 
@@ -35,7 +34,7 @@ public class ClientSocketTest {
 
             }
         };
-        clientSocket = new ClientSocket(fakeSocket);
+        clientSocket = new ClientSocket(fakeSocket, new HttpResponseFormatter());
     }
 
     @Test

--- a/src/test/java/HttpRequestParserTest.java
+++ b/src/test/java/HttpRequestParserTest.java
@@ -5,8 +5,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.*;
+import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -15,6 +15,8 @@ public class HttpRequestParserTest {
     public ExpectedException expectedException = ExpectedException.none();
     private InputStream getRequestInputStream;
     private HttpRequestParser parser;
+    private String postFixture;
+    private InputStream postRequestInputStream;
 
     @Before
     public void setupFixture() {
@@ -26,6 +28,12 @@ public class HttpRequestParserTest {
                 "Accept-Encoding: gzip,deflate\r\n\r\n";
         getRequestInputStream = new ByteArrayInputStream(getRequest.getBytes());
         parser = new HttpRequestParser();
+        postFixture = "POST /path/script.cgi HTTP/1.1\r\n" +
+                "From: frog@jmarshall.com\r\n" +
+                "User-Agent: HTTPTool/1.1\r\n" +
+                "Content-Type: application/x-www-form-urlencoded\r\n" +
+                "Content-Length: 32\r\n\r\nhome=Cosby&favorite+flavor=flies";
+        postRequestInputStream = new ByteArrayInputStream(postFixture.getBytes());
     }
 
     @Test
@@ -51,6 +59,25 @@ public class HttpRequestParserTest {
         HttpRequest request = parser.parse(getRequestInputStream);
 
         assertThat(request.getRequestUri(), is("/"));
+    }
+
+    @Test
+    public void parsesMapOfHeaderProperties() {
+        HttpRequest request = parser.parse(postRequestInputStream);
+        Map<String, String> headerProperties = request.headerParameters();
+
+        assertThat(headerProperties.get("From"), is("frog@jmarshall.com"));
+        assertThat(headerProperties.get("User-Agent"), is("HTTPTool/1.1"));
+        assertThat(headerProperties.get("Content-Type"), is("application/x-www-form-urlencoded"));
+        assertThat(headerProperties.get("Content-Length"), is("32"));
+    }
+
+
+    @Test
+    public void parsesBodyFromPostRequest() {
+        HttpRequest request = parser.parse(postRequestInputStream);
+
+        assertThat(request.getBody(), is("home=Cosby&favorite+flavor=flies"));
     }
 }
 

--- a/src/test/java/HttpRequestParserTest.java
+++ b/src/test/java/HttpRequestParserTest.java
@@ -15,7 +15,6 @@ public class HttpRequestParserTest {
     public ExpectedException expectedException = ExpectedException.none();
     private InputStream getRequestInputStream;
     private HttpRequestParser parser;
-    private String postFixture;
     private InputStream postRequestInputStream;
 
     @Before
@@ -28,7 +27,8 @@ public class HttpRequestParserTest {
                 "Accept-Encoding: gzip,deflate\r\n\r\n";
         getRequestInputStream = new ByteArrayInputStream(getRequest.getBytes());
         parser = new HttpRequestParser();
-        postFixture = "POST /path/script.cgi HTTP/1.1\r\n" +
+
+        String postFixture = "POST /path/script.cgi HTTP/1.1\r\n" +
                 "From: frog@jmarshall.com\r\n" +
                 "User-Agent: HTTPTool/1.1\r\n" +
                 "Content-Type: application/x-www-form-urlencoded\r\n" +

--- a/src/test/java/HttpRequestParserTest.java
+++ b/src/test/java/HttpRequestParserTest.java
@@ -72,7 +72,6 @@ public class HttpRequestParserTest {
         assertThat(headerProperties.get("Content-Length"), is("32"));
     }
 
-
     @Test
     public void parsesBodyFromPostRequest() {
         HttpRequest request = parser.parse(postRequestInputStream);

--- a/src/test/java/HttpRequestProcessorTest.java
+++ b/src/test/java/HttpRequestProcessorTest.java
@@ -55,7 +55,7 @@ public class HttpRequestProcessorTest {
         HttpRequest httpRequest = new HttpRequest("options", "/method_options", Collections.EMPTY_MAP, "");
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
-        assertThat(httpResponse.allowedMethods(), containsInAnyOrder("GET", "HEAD", "POST", "OPTIONS", "PUT"));
+        assertThat(httpResponse.allowedMethods(), containsInAnyOrder(HttpMethods.GET, HttpMethods.HEAD, HttpMethods.POST, HttpMethods.OPTIONS, HttpMethods.PUT));
     }
 
 //    @Test

--- a/src/test/java/HttpRequestProcessorTest.java
+++ b/src/test/java/HttpRequestProcessorTest.java
@@ -1,6 +1,8 @@
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -16,7 +18,7 @@ public class HttpRequestProcessorTest {
 
     @Test
     public void provides404WhenNoRoutesMet() {
-        HttpRequest httpRequest = new HttpRequest("get", "/unknown/route");
+        HttpRequest httpRequest = new HttpRequest("get", "/unknown/route", Collections.EMPTY_MAP, "");
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
@@ -25,7 +27,7 @@ public class HttpRequestProcessorTest {
 
     @Test
     public void simpleGetReturnsCode200() {
-        HttpRequest httpRequest = new HttpRequest("get", "/");
+        HttpRequest httpRequest = new HttpRequest("get", "/", Collections.EMPTY_MAP, "");
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
@@ -34,7 +36,7 @@ public class HttpRequestProcessorTest {
 
     @Test
     public void simplePutReturnsCode200() {
-        HttpRequest httpRequest = new HttpRequest("post", "/form");
+        HttpRequest httpRequest = new HttpRequest("post", "/form", Collections.EMPTY_MAP, "");
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
         assertThat(httpResponse.statusCode(), is(200));
@@ -42,7 +44,7 @@ public class HttpRequestProcessorTest {
 
     @Test
     public void simpleOptionReturns200Code() {
-        HttpRequest httpRequest = new HttpRequest("options", "/method_options");
+        HttpRequest httpRequest = new HttpRequest("options", "/method_options", Collections.EMPTY_MAP, "");
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
         assertThat(httpResponse.statusCode(), is(200));
@@ -50,9 +52,27 @@ public class HttpRequestProcessorTest {
 
     @Test
     public void simpleOptionReturnsMethodsInAllow() {
-        HttpRequest httpRequest = new HttpRequest("options", "/method_options");
+        HttpRequest httpRequest = new HttpRequest("options", "/method_options", Collections.EMPTY_MAP, "");
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
         assertThat(httpResponse.allowedMethods(), containsInAnyOrder("GET", "HEAD", "POST", "OPTIONS", "PUT"));
     }
+
+//    @Test
+//    public void postingContentCreatesResource() {
+//        HttpRequest httpRequest = new HttpRequest("post", "/form");
+//
+//        /***
+//         * POST /path/script.cgi HTTP/1.0
+//         From: frog@jmarshall.com
+//         User-Agent: HTTPTool/1.0
+//         Content-Type: application/x-www-form-urlencoded
+//         Content-Length: 32
+//
+//         home=Cosby&favorite+flavor=flies
+//         */
+//        HttpResponse httpResponse = requestProcessor.process(httpRequest);
+//
+//        assertThat(httpResponse.allowedMethods(), containsInAnyOrder("GET", "HEAD", "POST", "OPTIONS", "PUT"));
+//    }
 }

--- a/src/test/java/HttpRequestProcessorTest.java
+++ b/src/test/java/HttpRequestProcessorTest.java
@@ -1,8 +1,7 @@
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
-
+import static java.util.Collections.EMPTY_MAP;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -18,7 +17,7 @@ public class HttpRequestProcessorTest {
 
     @Test
     public void provides404WhenNoRoutesMet() {
-        HttpRequest httpRequest = new HttpRequest("get", "/unknown/route", Collections.EMPTY_MAP, "");
+        HttpRequest httpRequest = new HttpRequest("get", "/unknown/route", EMPTY_MAP, "");
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
@@ -27,7 +26,7 @@ public class HttpRequestProcessorTest {
 
     @Test
     public void simpleGetReturnsCode200() {
-        HttpRequest httpRequest = new HttpRequest("get", "/", Collections.EMPTY_MAP, "");
+        HttpRequest httpRequest = new HttpRequest("get", "/", EMPTY_MAP, "");
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
@@ -36,7 +35,7 @@ public class HttpRequestProcessorTest {
 
     @Test
     public void simplePutReturnsCode200() {
-        HttpRequest httpRequest = new HttpRequest("post", "/form", Collections.EMPTY_MAP, "");
+        HttpRequest httpRequest = new HttpRequest("post", "/form", EMPTY_MAP, "");
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
         assertThat(httpResponse.statusCode(), is(200));
@@ -44,7 +43,7 @@ public class HttpRequestProcessorTest {
 
     @Test
     public void simpleOptionReturns200Code() {
-        HttpRequest httpRequest = new HttpRequest("options", "/method_options", Collections.EMPTY_MAP, "");
+        HttpRequest httpRequest = new HttpRequest("options", "/method_options", EMPTY_MAP, "");
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
         assertThat(httpResponse.statusCode(), is(200));
@@ -52,7 +51,7 @@ public class HttpRequestProcessorTest {
 
     @Test
     public void simpleOptionReturnsMethodsInAllow() {
-        HttpRequest httpRequest = new HttpRequest("options", "/method_options", Collections.EMPTY_MAP, "");
+        HttpRequest httpRequest = new HttpRequest("options", "/method_options", EMPTY_MAP, "");
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
         assertThat(httpResponse.allowedMethods(), containsInAnyOrder(HttpMethods.GET, HttpMethods.HEAD, HttpMethods.POST, HttpMethods.OPTIONS, HttpMethods.PUT));

--- a/src/test/java/HttpResponseBuilderTest.java
+++ b/src/test/java/HttpResponseBuilderTest.java
@@ -37,9 +37,9 @@ public class HttpResponseBuilderTest {
     @Test
     public void buildsResponseWithAllowMethods() {
         HttpResponse response = HttpResponseBuilder.anHttpResponseBuilder()
-                .withAllowMethods("GET", "POST")
+                .withAllowMethods(HttpMethods.GET, HttpMethods.POST)
                 .build();
 
-        assertThat(response.allowedMethods().containsAll(Arrays.asList("GET", "POST")), is(true));
+        assertThat(response.allowedMethods().containsAll(Arrays.asList(HttpMethods.GET, HttpMethods.POST)), is(true));
     }
 }

--- a/src/test/java/HttpResponseFormatterTest.java
+++ b/src/test/java/HttpResponseFormatterTest.java
@@ -37,7 +37,7 @@ public class HttpResponseFormatterTest {
 
     @Test
     public void statusLineWithAllowMethodsResponseFormat() {
-        HttpResponse response = HttpResponseBuilder.anHttpResponseBuilder().withStatus(200).withReasonPhrase("OK").withAllowMethods("GET", "PUT").build();
+        HttpResponse response = HttpResponseBuilder.anHttpResponseBuilder().withStatus(200).withReasonPhrase("OK").withAllowMethods(HttpMethods.GET, HttpMethods.PUT).build();
 
         byte[] formattedResponse = formatter.format(response);
 
@@ -50,7 +50,7 @@ public class HttpResponseFormatterTest {
         expectedException.expectMessage("Error in creating HTTP Response");
         expectedException.expectCause(IsInstanceOf.<Throwable>instanceOf(UnsupportedEncodingException.class));
 
-        HttpResponse response = HttpResponseBuilder.anHttpResponseBuilder().withStatus(200).withReasonPhrase("OK").withAllowMethods("GET", "PUT").build();
+        HttpResponse response = HttpResponseBuilder.anHttpResponseBuilder().withStatus(200).withReasonPhrase("OK").withAllowMethods(HttpMethods.GET, HttpMethods.PUT).build();
         responseFormatterThrowingException.format(response);
     }
 }

--- a/src/test/java/HttpServerSocketTest.java
+++ b/src/test/java/HttpServerSocketTest.java
@@ -22,7 +22,7 @@ public class HttpServerSocketTest {
                 throw new IOException("Throws exception for test");
             }
         };
-        httpServerSocket = new HttpServerSocket(fakeServerSocket);
+        httpServerSocket = new HttpServerSocket(fakeServerSocket, new HttpResponseFormatter());
     }
 
     @Test

--- a/src/test/java/RequestProcessorSpy.java
+++ b/src/test/java/RequestProcessorSpy.java
@@ -1,5 +1,3 @@
-import java.util.Collections;
-
 public class RequestProcessorSpy implements RequestProcessor {
     private boolean hasProcessed = false;
 
@@ -10,6 +8,9 @@ public class RequestProcessorSpy implements RequestProcessor {
     @Override
     public HttpResponse process(HttpRequest httpRequest) {
         hasProcessed = true;
-        return new HttpResponse(200, "HTTP/1.1", "OK", Collections.emptyList());
+        return HttpResponseBuilder.anHttpResponseBuilder()
+                .withStatus(200)
+                .withReasonPhrase("OK")
+                .build();
     }
 }

--- a/src/test/java/ServerSocketSpy.java
+++ b/src/test/java/ServerSocketSpy.java
@@ -3,7 +3,7 @@ class ServerSocketSpy extends HttpServerSocket {
     private ClientSpy clientToReturn;
 
     public ServerSocketSpy(ClientSpy clientSpy) {
-        super(null);
+        super(null, new HttpResponseFormatter());
         this.clientToReturn = clientSpy;
     }
 


### PR DESCRIPTION
@jsuchy @ecomba @christophgockel
- HTTP request header parameters and request body is now parsed and stored in HttpRequest (in preparation for upcoming test cases)

Before adding the new functionality the following refactoring was taken:
- HttpRequest is simplified, and is now a pojo
- Formatting of the HttpRequest extracted into ResponseFormatter (adhering to SRP)
- ClientSocket calls the formatter (as it is responsible for giving the response to the client)
- enum used for HttpMethods. This is used in the HttpResponse objects (to prevent duplication and form a grouping).
- Request builder introduced as a tidy up

Routing is not refactored yet, I want to see how it evolves a little more before making the decision as to how to design it.
