### PR TITLE
Image content

### DIFF
--- a/src/main/java/FileFinder.java
+++ b/src/main/java/FileFinder.java
@@ -1,6 +1,6 @@
-import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 class FileFinder implements ResourceFinder {
     private String rootPath;
@@ -9,12 +9,10 @@ class FileFinder implements ResourceFinder {
         this.rootPath = rootPath;
     }
 
-    public String getContentOf(String resourcePath) {
+    public byte[] getContentOf(String resourcePath) {
         try {
             System.out.println("Looking up resource at location: " + rootPath + resourcePath);
-            String content = readContentsOfFile(filename(resourcePath));
-            System.out.println("contents of file found " + content);
-            return content;
+            return Files.readAllBytes(Paths.get(filename(resourcePath)));
         } catch (IOException e) {
             System.out.println("FILE IS NOT Found!!!");
             return noResourceContentAvailable();
@@ -25,28 +23,7 @@ class FileFinder implements ResourceFinder {
         return rootPath + resourcePath;
     }
 
-    private String readContentsOfFile(String filename) throws IOException {
-        BufferedReader resourceReader = new BufferedReader(new FileReader(filename));
-        StringBuilder content = new StringBuilder("");
-
-        String line = readLine(resourceReader);
-
-        while (hasContent(line)) {
-            content.append(line);
-            line = readLine(resourceReader);
-        }
-        return content.toString();
-    }
-
-    private String readLine(BufferedReader resourceReader) throws IOException {
-        return resourceReader.readLine();
-    }
-
-    private boolean hasContent(String line) {
-        return line != null;
-    }
-
-    private String noResourceContentAvailable() {
+    private byte[] noResourceContentAvailable() {
         return null;
     }
 }

--- a/src/main/java/FileResourceHandler.java
+++ b/src/main/java/FileResourceHandler.java
@@ -22,17 +22,17 @@ public class FileResourceHandler implements ResourceHandler {
 
     @Override
     public boolean delete(String fileName) {
-        File resource = new File(filename(fileName));
+        File resource = new File(fullPath(fileName));
         return resource.delete();
     }
 
-    private String filename(String fileName) {
+    private String fullPath(String fileName) {
         return absolutePath + fileName;
     }
 
     //TODO should this be injected, but then what is the responsibilities of this class
     protected void writeContentToFile(String filename, String content) throws IOException {
-        File resource = new File(filename(filename));
+        File resource = new File(fullPath(filename));
         FileWriter fileWriter = new FileWriter(resource);
         fileWriter.write(content);
         fileWriter.flush();

--- a/src/main/java/HttpRequestProcessor.java
+++ b/src/main/java/HttpRequestProcessor.java
@@ -44,6 +44,9 @@ public class HttpRequestProcessor implements RequestProcessor {
             httpResponseBuilder.withStatus(200).withReasonPhrase("OK").withAllowMethods(HttpMethods.values());
         } else if(httpRequest.getRequestUri().equals("/redirect")) {
             httpResponseBuilder.withStatus(302).withReasonPhrase("Found").withLocation("http://localhost:5000/");
+        } else if(httpRequest.getRequestUri().contains("/image")) {
+            byte[] body = resourceFinder.getContentOf(httpRequest.getRequestUri());
+            httpResponseBuilder.withStatus(200).withBody(body);
         }
 
         else {

--- a/src/main/java/HttpRequestProcessor.java
+++ b/src/main/java/HttpRequestProcessor.java
@@ -18,7 +18,7 @@ public class HttpRequestProcessor implements RequestProcessor {
             System.out.println("routing at /form with " + httpRequest.getMethod());
             if (httpRequest.getMethod().equals(HttpMethods.GET.name())) {
                 System.out.println("GET /FORM");
-                String body = resourceFinder.getContentOf(httpRequest.getRequestUri());
+                byte[] body = resourceFinder.getContentOf(httpRequest.getRequestUri());
                 System.out.println("BODY FROM THE GET IS " + body);
                 httpResponseBuilder.withBody(body);
             }
@@ -26,13 +26,13 @@ public class HttpRequestProcessor implements RequestProcessor {
             if (httpRequest.getMethod().equals(HttpMethods.POST.name())) {
                 System.out.println("POST /FORM");
                 resourceHandler.write(httpRequest.getRequestUri(), httpRequest.getBody());
-                httpResponseBuilder.withBody(httpRequest.getBody());
+                httpResponseBuilder.withBody(httpRequest.getBody().getBytes());
             }
 
             if (httpRequest.getMethod().equals(HttpMethods.PUT.name())) {
                 System.out.println("PUT /FORM");
                 resourceHandler.write(httpRequest.getRequestUri(), httpRequest.getBody());
-                httpResponseBuilder.withBody(httpRequest.getBody());
+                httpResponseBuilder.withBody(httpRequest.getBody().getBytes());
             }
 
             if (httpRequest.getMethod().equals(HttpMethods.DELETE.name())) {

--- a/src/main/java/HttpResponse.java
+++ b/src/main/java/HttpResponse.java
@@ -7,14 +7,14 @@ class HttpResponse {
     private final List<HttpMethods> allowedMethods;
     private String httpVersion;
     private String reasonPhrase;
-    private String body;
+    private byte[] body;
 
     protected HttpResponse(int statusCode,
                            String httpVersion,
                            String reasonPhrase,
                            String location,
                            List<HttpMethods> allowedMethods,
-                           String body) {
+                           byte[] body) {
         this.statusCode = statusCode;
         this.httpVersion = httpVersion;
         this.location = location;
@@ -40,12 +40,12 @@ class HttpResponse {
         return allowedMethods;
     }
 
-    public String body() {
+    public byte[] body() {
         return body;
     }
 
     public String location() {
-   return location;
+        return location;
     }
 }
 

--- a/src/main/java/HttpResponseBuilder.java
+++ b/src/main/java/HttpResponseBuilder.java
@@ -6,7 +6,7 @@ public final class HttpResponseBuilder {
     private int statusCode;
     private String reasonPhrase;
     private List<HttpMethods> allowedMethods = new ArrayList<>();
-    private String body;
+    private byte[] body;
     private String location;
 
     public static HttpResponseBuilder anHttpResponseBuilder() {
@@ -37,7 +37,7 @@ public final class HttpResponseBuilder {
         return this;
     }
 
-    public HttpResponseBuilder withBody(String content) {
+    public HttpResponseBuilder withBody(byte[] content) {
         this.body = content;
         return this;
     }

--- a/src/main/java/ResourceFinder.java
+++ b/src/main/java/ResourceFinder.java
@@ -1,4 +1,4 @@
 public interface ResourceFinder {
-    String getContentOf(String resourcePath);
+    byte[] getContentOf(String resourcePath);
 }
 

--- a/src/test/java/FileFinderTest.java
+++ b/src/test/java/FileFinderTest.java
@@ -28,15 +28,15 @@ public class FileFinderTest {
     public void looksupExistingResource() throws IOException {
         File resource = setupResourceWithContent();
         ResourceFinder resourceFinder = new FileFinder(absolutePath);
-        String resourceContent = resourceFinder.getContentOf("/" + resource.getName());
+        byte[] resourceContent = resourceFinder.getContentOf("/" + resource.getName());
 
-        assertThat(resourceContent, is("My=Data"));
+        assertThat(resourceContent, is("My=Data".getBytes()));
     }
 
     @Test
     public void looksupNonExistingResource() {
         ResourceFinder resourceFinder = new FileFinder(absolutePath);
-        String resourceContent = resourceFinder.getContentOf("non-existing-resource");
+        byte[] resourceContent = resourceFinder.getContentOf("non-existing-resource");
 
         assertThat(resourceContent, CoreMatchers.nullValue());
     }

--- a/src/test/java/FileResourceHandlerTest.java
+++ b/src/test/java/FileResourceHandlerTest.java
@@ -32,7 +32,7 @@ public class FileResourceHandlerTest {
         ResourceHandler resourceHandler = new FileResourceHandler(absolutePath);
         resourceHandler.write(resourceName, "My=Data");
 
-        assertThat(getContentOfResource(), is("My=Data"));
+        assertThat(getContentOfResource(), is("My=Data".getBytes()));
     }
 
     @Test
@@ -41,7 +41,7 @@ public class FileResourceHandlerTest {
         resourceHandler.write(resourceName, "originalData");
         resourceHandler.write(resourceName, "UpdatedData");
 
-        assertThat(getContentOfResource(), is("UpdatedData"));
+        assertThat(getContentOfResource(), is("UpdatedData".getBytes()));
     }
 
     @Test
@@ -74,7 +74,7 @@ public class FileResourceHandlerTest {
         resourceHandler.write(resourceName, "anything");
     }
 
-    private String getContentOfResource() {
+    private byte[] getContentOfResource() {
         ResourceFinder reader = new FileFinder(absolutePath);
         return reader.getContentOf(resourceName);
     }

--- a/src/test/java/HttpRequestProcessorTest.java
+++ b/src/test/java/HttpRequestProcessorTest.java
@@ -66,7 +66,7 @@ public class HttpRequestProcessorTest {
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
         assertThat(httpResponse.statusCode(), is(200));
-        assertThat(httpResponse.body(), is("My=Data"));
+        assertThat(httpResponse.body(), is("My=Data".getBytes()));
         assertThat(resourceFinderSpy.hasLookedupResource(), is(true));
     }
 
@@ -76,7 +76,7 @@ public class HttpRequestProcessorTest {
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
         assertThat(httpResponse.statusCode(), is(200));
-        assertThat(httpResponse.body(), is("content"));
+        assertThat(httpResponse.body(), is("content".getBytes()));
         assertThat(resourceWriterSpy.hasWrittenToResource(), is(true));
     }
 
@@ -86,7 +86,7 @@ public class HttpRequestProcessorTest {
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
         assertThat(httpResponse.statusCode(), is(200));
-        assertThat(httpResponse.body(), is("content"));
+        assertThat(httpResponse.body(), is("content".getBytes()));
         assertThat(resourceWriterSpy.hasWrittenToResource(), is(true));
     }
 
@@ -101,9 +101,6 @@ public class HttpRequestProcessorTest {
 
     @Test
     public void redirectReturns302() {
-//        HTTP/1.1 302 Found
-//        Location: http://www.iana.org/domains/example/
-
         HttpRequest httpRequest = new HttpRequest(HttpMethods.GET.name(), "/redirect", EMPTY_MAP, "");
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 

--- a/src/test/java/HttpRequestProcessorTest.java
+++ b/src/test/java/HttpRequestProcessorTest.java
@@ -108,4 +108,22 @@ public class HttpRequestProcessorTest {
         assertThat(httpResponse.location(), is("http://localhost:5000/"));
     }
 
+    @Test
+    public void getImageContentForJpeg() {
+        HttpRequest httpRequest = new HttpRequest(HttpMethods.GET.name(), "/image.jpeg", EMPTY_MAP, "");
+        HttpResponse httpResponse = requestProcessor.process(httpRequest);
+
+        assertThat(httpResponse.statusCode(), is(200));
+        assertThat(resourceFinderSpy.hasLookedupResource(), is(true));
+    }
+
+    @Test
+    public void getImageContentForPng() {
+        HttpRequest httpRequest = new HttpRequest(HttpMethods.GET.name(), "/image.png", EMPTY_MAP, "");
+        HttpResponse httpResponse = requestProcessor.process(httpRequest);
+
+        assertThat(httpResponse.statusCode(), is(200));
+        assertThat(resourceFinderSpy.hasLookedupResource(), is(true));
+    }
+
 }

--- a/src/test/java/HttpResponseBuilderTest.java
+++ b/src/test/java/HttpResponseBuilderTest.java
@@ -47,10 +47,10 @@ public class HttpResponseBuilderTest {
     public void buildsResponseWithBody() {
         HttpResponse response = HttpResponseBuilder.anHttpResponseBuilder()
                 .withStatus(200)
-                .withBody("My=Data")
+                .withBody("My=Data".getBytes())
                 .build();
 
-        assertThat(response.body(), is("My=Data"));
+        assertThat(response.body(), is("My=Data".getBytes()));
     }
 
     @Test

--- a/src/test/java/HttpResponseFormatterTest.java
+++ b/src/test/java/HttpResponseFormatterTest.java
@@ -55,7 +55,7 @@ public class HttpResponseFormatterTest {
 
     @Test
     public void bodyIncludedOnResponse() {
-        HttpResponse response = HttpResponseBuilder.anHttpResponseBuilder().withStatus(200).withReasonPhrase("OK").withBody("My=Data").build();
+        HttpResponse response = HttpResponseBuilder.anHttpResponseBuilder().withStatus(200).withReasonPhrase("OK").withBody("My=Data".getBytes()).build();
 
         byte[] formattedResponse = formatter.format(response);
 

--- a/src/test/java/ResourceFinderSpy.java
+++ b/src/test/java/ResourceFinderSpy.java
@@ -2,9 +2,9 @@ public class ResourceFinderSpy implements ResourceFinder {
     private boolean hasLookedUpResource;
 
     @Override
-    public String getContentOf(String resourcePath) {
+    public byte[] getContentOf(String resourcePath) {
         hasLookedUpResource = true;
-        return "My=Data";
+        return "My=Data".getBytes();
     }
 
     public boolean hasLookedupResource() {


### PR DESCRIPTION
@jsuchy @ecomba @christophgockel

This PR implements the image content test case.
The HTTPResponse body has been updated to be stored as a byte[].  This simplifies reading the resource in, and the same logic can be used for both text and image resources.
