### PR TITLE
File contents

### DIFF
--- a/src/main/java/server/HttpRouteProcessor.java
+++ b/src/main/java/server/HttpRouteProcessor.java
@@ -29,6 +29,7 @@ public class HttpRouteProcessor implements RouteProcessor {
         routes.put(new RoutingCriteria("/image.jpeg", GET.name()), new ReadResource(resourceHandler));
         routes.put(new RoutingCriteria("/image.png", GET.name()), new ReadResource(resourceHandler));
         routes.put(new RoutingCriteria("/image.gif", GET.name()), new ReadResource(resourceHandler));
+        routes.put(new RoutingCriteria("/file1", GET.name()), new ReadResource(resourceHandler));
     }
 
     @Override

--- a/src/test/java/server/HttpRouteProcessorTest.java
+++ b/src/test/java/server/HttpRouteProcessorTest.java
@@ -194,4 +194,18 @@ public class HttpRouteProcessorTest {
         assertThat(resourceHandlerSpy.hasReadResource(), is(true));
     }
 
+    @Test
+    public void getFileContents() {
+        HttpRequest httpRequest = anHttpRequestBuilder()
+                .withRequestUri("/file1")
+                .withRequestLine(HttpMethods.GET.name())
+                .build();
+
+        HttpResponse httpResponse = requestProcessor.process(httpRequest);
+
+        assertThat(httpResponse.statusCode(), is(StatusCode.OK));
+        assertThat(httpResponse.body(), is("My=Data".getBytes()));
+        assertThat(resourceHandlerSpy.hasReadResource(), is(true));
+
+    }
 }


### PR DESCRIPTION
@jsuchy @ecomba @christophgockel
This change is done on top of the earlier PR, so you need only look at the last commit.

This routes /file1 and returns it's content, required for the Fitnesse test 'FileContents'. 

Because of the refactoring I completed last night, adding this functionality was really quick. I only had to configure a new route, then could use the (already existing) action to read the contents of the resource. :+1: 
