### PR TITLE
Method not allowed

### DIFF
--- a/src/main/java/server/HttpMethods.java
+++ b/src/main/java/server/HttpMethods.java
@@ -6,5 +6,14 @@ public enum HttpMethods {
     OPTIONS,
     POST,
     PUT,
-    DELETE
+    DELETE;
+
+    public static boolean isBogus(String method) {
+        try {
+            HttpMethods.valueOf(method);
+            return false;
+        } catch (IllegalArgumentException e) {
+            return true;
+        }
+    }
 }

--- a/src/main/java/server/HttpRouteProcessor.java
+++ b/src/main/java/server/HttpRouteProcessor.java
@@ -31,6 +31,8 @@ public class HttpRouteProcessor implements RouteProcessor {
         routes.put(new RoutingCriteria("/image.gif", GET.name()), new ReadResource(resourceHandler));
         routes.put(new RoutingCriteria("/file1", GET.name()), new ReadResource(resourceHandler));
         routes.put(new RoutingCriteria("/file1", PUT.name()), new MethodNotAllowed());
+        routes.put(new RoutingCriteria("/text-file.txt", GET.name()), new ReadResource(resourceHandler));
+        routes.put(new RoutingCriteria("/text-file.txt", POST.name()), new MethodNotAllowed());
     }
 
     @Override

--- a/src/main/java/server/HttpRouteProcessor.java
+++ b/src/main/java/server/HttpRouteProcessor.java
@@ -30,6 +30,7 @@ public class HttpRouteProcessor implements RouteProcessor {
         routes.put(new RoutingCriteria("/image.png", GET.name()), new ReadResource(resourceHandler));
         routes.put(new RoutingCriteria("/image.gif", GET.name()), new ReadResource(resourceHandler));
         routes.put(new RoutingCriteria("/file1", GET.name()), new ReadResource(resourceHandler));
+        routes.put(new RoutingCriteria("/file1", PUT.name()), new MethodNotAllowed());
     }
 
     @Override

--- a/src/main/java/server/HttpRouteProcessor.java
+++ b/src/main/java/server/HttpRouteProcessor.java
@@ -38,9 +38,18 @@ public class HttpRouteProcessor implements RouteProcessor {
         System.out.println("Routing key is: " + httpRequest.getRequestUri() + httpRequest.getMethod());
         RoutingCriteria routingCriteria = new RoutingCriteria(httpRequest.getRequestUri(), httpRequest.getMethod());
 
-        return routes.get(routingCriteria) != null ?
-                routes.get(routingCriteria).process(httpRequest) :
-                new UnknownRoute().process(httpRequest);
+        if (routes.get(routingCriteria) != null) {
+            return routes.get(routingCriteria).process(httpRequest);
+        } else if (isBogusMethod(httpRequest)) {
+            return new MethodNotAllowed().process(httpRequest);
+        } else {
+            return new UnknownRoute().process(httpRequest);
+        }
+    }
+
+    private boolean isBogusMethod(HttpRequest httpRequest) {
+        return isBogus(httpRequest.getMethod());
+
     }
 }
 

--- a/src/main/java/server/HttpRouteProcessor.java
+++ b/src/main/java/server/HttpRouteProcessor.java
@@ -55,4 +55,3 @@ public class HttpRouteProcessor implements RouteProcessor {
     }
 }
 
-

--- a/src/main/java/server/StatusCode.java
+++ b/src/main/java/server/StatusCode.java
@@ -3,7 +3,8 @@ package server;
 public enum StatusCode {
     OK(200, "OK"),
     NOT_FOUND(404, "Not Found"),
-    FOUND(302, "Found");
+    FOUND(302, "Found"),
+    METHOD_NOT_ALLOWED(405, "Method Not Allowed");
 
     private final int statusCode;
     private final String reasonPhrase;

--- a/src/main/java/server/actions/DeleteResource.java
+++ b/src/main/java/server/actions/DeleteResource.java
@@ -1,9 +1,12 @@
 package server.actions;
 
-import server.*;
+import server.Action;
+import server.ResourceHandler;
+import server.StatusCode;
 import server.messages.HttpRequest;
 import server.messages.HttpResponse;
-import server.messages.HttpResponseBuilder;
+
+import static server.messages.HttpResponseBuilder.anHttpResponseBuilder;
 
 public class DeleteResource implements Action {
     private final ResourceHandler resourceHandler;
@@ -14,10 +17,9 @@ public class DeleteResource implements Action {
 
     @Override
     public HttpResponse process(HttpRequest request) {
-        System.out.println("DELETE/FORM");
         resourceHandler.delete(request.getRequestUri());
 
-        return HttpResponseBuilder.anHttpResponseBuilder()
+        return anHttpResponseBuilder()
                 .withStatusCode(StatusCode.OK)
                 .build();
     }

--- a/src/main/java/server/actions/MethodNotAllowed.java
+++ b/src/main/java/server/actions/MethodNotAllowed.java
@@ -1,6 +1,7 @@
 package server.actions;
 
 import server.Action;
+import server.HttpMethods;
 import server.StatusCode;
 import server.messages.HttpRequest;
 import server.messages.HttpResponse;
@@ -9,14 +10,12 @@ import static server.messages.HttpResponseBuilder.anHttpResponseBuilder;
 
 public class MethodNotAllowed implements Action {
 
-    public MethodNotAllowed() {
-
-    }
-
     @Override
     public HttpResponse process(HttpRequest request) {
+
         return anHttpResponseBuilder()
                 .withStatusCode(StatusCode.METHOD_NOT_ALLOWED)
+                .withAllowMethods(HttpMethods.values())
                 .build();
     }
 }

--- a/src/main/java/server/actions/MethodNotAllowed.java
+++ b/src/main/java/server/actions/MethodNotAllowed.java
@@ -1,0 +1,22 @@
+package server.actions;
+
+import server.Action;
+import server.StatusCode;
+import server.messages.HttpRequest;
+import server.messages.HttpResponse;
+
+import static server.messages.HttpResponseBuilder.anHttpResponseBuilder;
+
+public class MethodNotAllowed implements Action {
+
+    public MethodNotAllowed() {
+
+    }
+
+    @Override
+    public HttpResponse process(HttpRequest request) {
+        return anHttpResponseBuilder()
+                .withStatusCode(StatusCode.METHOD_NOT_ALLOWED)
+                .build();
+    }
+}

--- a/src/main/java/server/actions/MethodOptions.java
+++ b/src/main/java/server/actions/MethodOptions.java
@@ -1,16 +1,19 @@
 package server.actions;
 
-import server.*;
+import server.Action;
+import server.HttpMethods;
 import server.messages.HttpRequest;
 import server.messages.HttpResponse;
-import server.messages.HttpResponseBuilder;
+
+import static server.StatusCode.OK;
+import static server.messages.HttpResponseBuilder.anHttpResponseBuilder;
 
 public class MethodOptions implements Action {
 
     @Override
     public HttpResponse process(HttpRequest request) {
-        return HttpResponseBuilder.anHttpResponseBuilder()
-                .withStatusCode(StatusCode.OK)
+        return anHttpResponseBuilder()
+                .withStatusCode(OK)
                 .withAllowMethods(HttpMethods.values())
                 .build();
     }

--- a/src/main/java/server/actions/WriteResource.java
+++ b/src/main/java/server/actions/WriteResource.java
@@ -1,9 +1,12 @@
 package server.actions;
 
-import server.*;
+import server.Action;
+import server.ResourceHandler;
+import server.StatusCode;
 import server.messages.HttpRequest;
 import server.messages.HttpResponse;
-import server.messages.HttpResponseBuilder;
+
+import static server.messages.HttpResponseBuilder.anHttpResponseBuilder;
 
 public class WriteResource implements Action {
     private final ResourceHandler resourceHandler;
@@ -14,10 +17,9 @@ public class WriteResource implements Action {
 
     @Override
     public HttpResponse process(HttpRequest request) {
-        System.out.println("PUT /FORM");
         resourceHandler.write(request.getRequestUri(), request.getBody());
 
-        return HttpResponseBuilder.anHttpResponseBuilder()
+        return anHttpResponseBuilder()
                 .withStatusCode(StatusCode.OK)
                 .withBody(request.getBody().getBytes())
                 .build();

--- a/src/test/java/server/HttpMethodsTest.java
+++ b/src/test/java/server/HttpMethodsTest.java
@@ -1,0 +1,19 @@
+package server;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HttpMethodsTest {
+
+    @Test
+    public void isValidMethod() {
+        assertThat(HttpMethods.isBogus("PUT"), is(false));
+    }
+
+    @Test
+    public void isBogusMethod() {
+        assertThat(HttpMethods.isBogus("BOGUS_METHOD"), is(true));
+    }
+}

--- a/src/test/java/server/HttpRouteProcessorTest.java
+++ b/src/test/java/server/HttpRouteProcessorTest.java
@@ -8,6 +8,7 @@ import server.messages.HttpResponse;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static server.StatusCode.*;
 import static server.messages.HttpRequestBuilder.anHttpRequestBuilder;
 
 public class HttpRouteProcessorTest {
@@ -29,7 +30,7 @@ public class HttpRouteProcessorTest {
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
-        assertThat(httpResponse.statusCode(), is(StatusCode.NOT_FOUND));
+        assertThat(httpResponse.statusCode(), is(NOT_FOUND));
     }
 
     @Test
@@ -41,7 +42,7 @@ public class HttpRouteProcessorTest {
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
-        assertThat(httpResponse.statusCode(), is(StatusCode.OK));
+        assertThat(httpResponse.statusCode(), is(OK));
         assertThat(resourceHandlerSpy.hasGotDirectoryContent(), is(true));
     }
 
@@ -55,7 +56,7 @@ public class HttpRouteProcessorTest {
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
-        assertThat(httpResponse.statusCode(), is(StatusCode.OK));
+        assertThat(httpResponse.statusCode(), is(OK));
     }
 
     @Test
@@ -67,7 +68,7 @@ public class HttpRouteProcessorTest {
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
-        assertThat(httpResponse.statusCode(), is(StatusCode.OK));
+        assertThat(httpResponse.statusCode(), is(OK));
     }
 
     @Test
@@ -91,7 +92,7 @@ public class HttpRouteProcessorTest {
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
-        assertThat(httpResponse.statusCode(), is(StatusCode.OK));
+        assertThat(httpResponse.statusCode(), is(OK));
         assertThat(resourceHandlerSpy.hasReadResource(), is(true));
     }
 
@@ -105,7 +106,7 @@ public class HttpRouteProcessorTest {
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
-        assertThat(httpResponse.statusCode(), is(StatusCode.OK));
+        assertThat(httpResponse.statusCode(), is(OK));
         assertThat(httpResponse.body(), is("content".getBytes()));
         assertThat(resourceHandlerSpy.hasWrittenToResource(), is(true));
     }
@@ -120,7 +121,7 @@ public class HttpRouteProcessorTest {
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
-        assertThat(httpResponse.statusCode(), is(StatusCode.OK));
+        assertThat(httpResponse.statusCode(), is(OK));
         assertThat(httpResponse.body(), is("content".getBytes()));
         assertThat(resourceHandlerSpy.hasWrittenToResource(), is(true));
     }
@@ -134,7 +135,7 @@ public class HttpRouteProcessorTest {
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
-        assertThat(httpResponse.statusCode(), is(StatusCode.OK));
+        assertThat(httpResponse.statusCode(), is(OK));
         assertThat(resourceHandlerSpy.hasDeletedResource(), is(true));
     }
 
@@ -147,7 +148,7 @@ public class HttpRouteProcessorTest {
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
-        assertThat(httpResponse.statusCode(), is(StatusCode.FOUND));
+        assertThat(httpResponse.statusCode(), is(FOUND));
         assertThat(httpResponse.location(), is("http://localhost:5000/"));
     }
 
@@ -161,7 +162,7 @@ public class HttpRouteProcessorTest {
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
-        assertThat(httpResponse.statusCode(), is(StatusCode.OK));
+        assertThat(httpResponse.statusCode(), is(OK));
         assertThat(httpResponse.body(), is("My=Data".getBytes()));
         assertThat(resourceHandlerSpy.hasReadResource(), is(true));
     }
@@ -175,7 +176,7 @@ public class HttpRouteProcessorTest {
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
-        assertThat(httpResponse.statusCode(), is(StatusCode.OK));
+        assertThat(httpResponse.statusCode(), is(OK));
         assertThat(httpResponse.body(), is("My=Data".getBytes()));
         assertThat(resourceHandlerSpy.hasReadResource(), is(true));
     }
@@ -189,7 +190,7 @@ public class HttpRouteProcessorTest {
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
-        assertThat(httpResponse.statusCode(), is(StatusCode.OK));
+        assertThat(httpResponse.statusCode(), is(OK));
         assertThat(httpResponse.body(), is("My=Data".getBytes()));
         assertThat(resourceHandlerSpy.hasReadResource(), is(true));
     }
@@ -203,9 +204,20 @@ public class HttpRouteProcessorTest {
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
-        assertThat(httpResponse.statusCode(), is(StatusCode.OK));
+        assertThat(httpResponse.statusCode(), is(OK));
         assertThat(httpResponse.body(), is("My=Data".getBytes()));
         assertThat(resourceHandlerSpy.hasReadResource(), is(true));
+    }
 
+    @Test
+    public void methodNotAllowed() {
+        HttpRequest httpRequest = anHttpRequestBuilder()
+                .withRequestUri("/file1")
+                .withRequestLine(HttpMethods.PUT.name())
+                .build();
+
+        HttpResponse httpResponse = requestProcessor.process(httpRequest);
+
+        assertThat(httpResponse.statusCode(), is(METHOD_NOT_ALLOWED));
     }
 }

--- a/src/test/java/server/HttpRouteProcessorTest.java
+++ b/src/test/java/server/HttpRouteProcessorTest.java
@@ -23,7 +23,7 @@ public class HttpRouteProcessorTest {
     }
 
     @Test
-    public void provides404WhenNoRoutesMet() {
+    public void routesNotConfiguredResultIn404Response() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/unknown/route")
                 .withRequestLine(GET.name())
@@ -35,7 +35,7 @@ public class HttpRouteProcessorTest {
     }
 
     @Test
-    public void listsDirectoryContent() {
+    public void routesHomeToDirectoryListing() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/")
                 .withRequestLine(GET.name())
@@ -48,44 +48,7 @@ public class HttpRouteProcessorTest {
     }
 
     @Test
-    public void simplePutReturnsCode200() {
-        HttpRequest httpRequest = anHttpRequestBuilder()
-                .withRequestUri("/form")
-                .withBody("image")
-                .withRequestLine(POST.name())
-                .build();
-
-        HttpResponse httpResponse = requestProcessor.process(httpRequest);
-
-        assertThat(httpResponse.statusCode(), is(OK));
-    }
-
-    @Test
-    public void simpleOptionReturns200Code() {
-        HttpRequest httpRequest = anHttpRequestBuilder()
-                .withRequestUri("/method_options")
-                .withRequestLine(OPTIONS.name())
-                .build();
-
-        HttpResponse httpResponse = requestProcessor.process(httpRequest);
-
-        assertThat(httpResponse.statusCode(), is(OK));
-    }
-
-    @Test
-    public void simpleOptionReturnsMethodsInAllow() {
-        HttpRequest httpRequest = anHttpRequestBuilder()
-                .withRequestUri("/method_options")
-                .withRequestLine(OPTIONS.name())
-                .build();
-
-        HttpResponse httpResponse = requestProcessor.process(httpRequest);
-
-        assertThat(httpResponse.allowedMethods(), containsInAnyOrder(GET, HEAD, POST, OPTIONS, PUT, DELETE));
-    }
-
-    @Test
-    public void getMethodLooksUpResourceForResponseBody() {
+    public void routesFormAndGetToReadResource() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/form")
                 .withRequestLine(GET.name())
@@ -98,7 +61,7 @@ public class HttpRouteProcessorTest {
     }
 
     @Test
-    public void postMethodCreatesAResource() {
+    public void routesFormAndPostToWriteResource() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/form")
                 .withBody("content")
@@ -113,7 +76,7 @@ public class HttpRouteProcessorTest {
     }
 
     @Test
-    public void putMethodUpdatesAResource() {
+    public void routesFormAndPutToWriteResource() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/form")
                 .withRequestLine(PUT.name())
@@ -128,7 +91,7 @@ public class HttpRouteProcessorTest {
     }
 
     @Test
-    public void deleteMethodRemovesResource() {
+    public void routesFormAndDeleteToRemoveResource() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/form")
                 .withRequestLine(DELETE.name())
@@ -141,7 +104,20 @@ public class HttpRouteProcessorTest {
     }
 
     @Test
-    public void redirectReturns302() {
+    public void routesMethodOptionsReturningAllowHeaders() {
+        HttpRequest httpRequest = anHttpRequestBuilder()
+                .withRequestUri("/method_options")
+                .withRequestLine(OPTIONS.name())
+                .build();
+
+        HttpResponse httpResponse = requestProcessor.process(httpRequest);
+
+        assertThat(httpResponse.statusCode(), is(OK));
+        assertThat(httpResponse.allowedMethods(), containsInAnyOrder(GET, HEAD, POST, OPTIONS, PUT, DELETE));
+    }
+
+    @Test
+    public void routesRedirecToNewUrl() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/redirect")
                 .withRequestLine(GET.name())
@@ -154,7 +130,7 @@ public class HttpRouteProcessorTest {
     }
 
     @Test
-    public void getImageContentForJpeg() {
+    public void routesJpegImageToReadResource() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/image.jpeg")
                 .withRequestLine(GET.name())
@@ -169,7 +145,7 @@ public class HttpRouteProcessorTest {
     }
 
     @Test
-    public void getImageContentForPng() {
+    public void routesPngImageToReadResource() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/image.png")
                 .withRequestLine(GET.name())
@@ -183,7 +159,7 @@ public class HttpRouteProcessorTest {
     }
 
     @Test
-    public void getImageContentForGif() {
+    public void routesGifImageToReadResource() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/image.gif")
                 .withRequestLine(GET.name())
@@ -197,7 +173,7 @@ public class HttpRouteProcessorTest {
     }
 
     @Test
-    public void getFileContents() {
+    public void routesFile1ToReadResource() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/file1")
                 .withRequestLine(GET.name())
@@ -211,7 +187,7 @@ public class HttpRouteProcessorTest {
     }
 
     @Test
-    public void methodNotAllowed() {
+    public void routesFileOneAndPutToMethodNotAllowed() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/file1")
                 .withRequestLine(PUT.name())
@@ -223,7 +199,7 @@ public class HttpRouteProcessorTest {
     }
 
     @Test
-    public void bogusRequestResultsInMethodNotAllowed() {
+    public void routesUnknownHttpMethodToMethodNotAllowed() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/file1")
                 .withRequestLine("BOGUS_METHOD")
@@ -235,7 +211,7 @@ public class HttpRouteProcessorTest {
     }
 
     @Test
-    public void readsResourceFromTextFile() {
+    public void routesTextFileToReadRequest() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/text-file.txt")
                 .withRequestLine(GET.name())
@@ -244,10 +220,11 @@ public class HttpRouteProcessorTest {
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
         assertThat(httpResponse.statusCode(), is(OK));
+        assertThat(resourceHandlerSpy.hasReadResource(), is(true));
     }
 
     @Test
-    public void bogusRequestAtRouteTextFile() {
+    public void routesTextFilePostToMethodNotAllowed() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/text-file.txt")
                 .withRequestLine(POST.name())

--- a/src/test/java/server/HttpRouteProcessorTest.java
+++ b/src/test/java/server/HttpRouteProcessorTest.java
@@ -220,4 +220,16 @@ public class HttpRouteProcessorTest {
 
         assertThat(httpResponse.statusCode(), is(METHOD_NOT_ALLOWED));
     }
+
+    @Test
+    public void bogusRequestResultsInMethodNotAllowed() {
+        HttpRequest httpRequest = anHttpRequestBuilder()
+                .withRequestUri("/file1")
+                .withRequestLine("BOGUS_METHOD")
+                .build();
+
+        HttpResponse httpResponse = requestProcessor.process(httpRequest);
+
+        assertThat(httpResponse.statusCode(), is(METHOD_NOT_ALLOWED));
+    }
 }

--- a/src/test/java/server/HttpRouteProcessorTest.java
+++ b/src/test/java/server/HttpRouteProcessorTest.java
@@ -8,6 +8,7 @@ import server.messages.HttpResponse;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static server.HttpMethods.*;
 import static server.StatusCode.*;
 import static server.messages.HttpRequestBuilder.anHttpRequestBuilder;
 
@@ -25,7 +26,7 @@ public class HttpRouteProcessorTest {
     public void provides404WhenNoRoutesMet() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/unknown/route")
-                .withRequestLine(HttpMethods.GET.name())
+                .withRequestLine(GET.name())
                 .build();
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
@@ -37,7 +38,7 @@ public class HttpRouteProcessorTest {
     public void listsDirectoryContent() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/")
-                .withRequestLine(HttpMethods.GET.name())
+                .withRequestLine(GET.name())
                 .build();
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
@@ -51,7 +52,7 @@ public class HttpRouteProcessorTest {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/form")
                 .withBody("image")
-                .withRequestLine(HttpMethods.POST.name())
+                .withRequestLine(POST.name())
                 .build();
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
@@ -63,7 +64,7 @@ public class HttpRouteProcessorTest {
     public void simpleOptionReturns200Code() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/method_options")
-                .withRequestLine(HttpMethods.OPTIONS.name())
+                .withRequestLine(OPTIONS.name())
                 .build();
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
@@ -75,19 +76,19 @@ public class HttpRouteProcessorTest {
     public void simpleOptionReturnsMethodsInAllow() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/method_options")
-                .withRequestLine(HttpMethods.OPTIONS.name())
+                .withRequestLine(OPTIONS.name())
                 .build();
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
-        assertThat(httpResponse.allowedMethods(), containsInAnyOrder(HttpMethods.GET, HttpMethods.HEAD, HttpMethods.POST, HttpMethods.OPTIONS, HttpMethods.PUT, HttpMethods.DELETE));
+        assertThat(httpResponse.allowedMethods(), containsInAnyOrder(GET, HEAD, POST, OPTIONS, PUT, DELETE));
     }
 
     @Test
     public void getMethodLooksUpResourceForResponseBody() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/form")
-                .withRequestLine(HttpMethods.GET.name())
+                .withRequestLine(GET.name())
                 .build();
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
@@ -101,7 +102,7 @@ public class HttpRouteProcessorTest {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/form")
                 .withBody("content")
-                .withRequestLine(HttpMethods.POST.name())
+                .withRequestLine(POST.name())
                 .build();
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
@@ -115,7 +116,7 @@ public class HttpRouteProcessorTest {
     public void putMethodUpdatesAResource() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/form")
-                .withRequestLine(HttpMethods.PUT.name())
+                .withRequestLine(PUT.name())
                 .withBody("content")
                 .build();
 
@@ -130,7 +131,7 @@ public class HttpRouteProcessorTest {
     public void deleteMethodRemovesResource() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/form")
-                .withRequestLine(HttpMethods.DELETE.name())
+                .withRequestLine(DELETE.name())
                 .build();
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
@@ -143,7 +144,7 @@ public class HttpRouteProcessorTest {
     public void redirectReturns302() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/redirect")
-                .withRequestLine(HttpMethods.GET.name())
+                .withRequestLine(GET.name())
                 .build();
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
@@ -156,7 +157,7 @@ public class HttpRouteProcessorTest {
     public void getImageContentForJpeg() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/image.jpeg")
-                .withRequestLine(HttpMethods.GET.name())
+                .withRequestLine(GET.name())
                 .withBody("My=Data")
                 .build();
 
@@ -171,7 +172,7 @@ public class HttpRouteProcessorTest {
     public void getImageContentForPng() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/image.png")
-                .withRequestLine(HttpMethods.GET.name())
+                .withRequestLine(GET.name())
                 .build();
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
@@ -185,7 +186,7 @@ public class HttpRouteProcessorTest {
     public void getImageContentForGif() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/image.gif")
-                .withRequestLine(HttpMethods.GET.name())
+                .withRequestLine(GET.name())
                 .build();
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
@@ -199,7 +200,7 @@ public class HttpRouteProcessorTest {
     public void getFileContents() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/file1")
-                .withRequestLine(HttpMethods.GET.name())
+                .withRequestLine(GET.name())
                 .build();
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
@@ -213,7 +214,7 @@ public class HttpRouteProcessorTest {
     public void methodNotAllowed() {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/file1")
-                .withRequestLine(HttpMethods.PUT.name())
+                .withRequestLine(PUT.name())
                 .build();
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
@@ -226,6 +227,30 @@ public class HttpRouteProcessorTest {
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestUri("/file1")
                 .withRequestLine("BOGUS_METHOD")
+                .build();
+
+        HttpResponse httpResponse = requestProcessor.process(httpRequest);
+
+        assertThat(httpResponse.statusCode(), is(METHOD_NOT_ALLOWED));
+    }
+
+    @Test
+    public void readsResourceFromTextFile() {
+        HttpRequest httpRequest = anHttpRequestBuilder()
+                .withRequestUri("/text-file.txt")
+                .withRequestLine(GET.name())
+                .build();
+
+        HttpResponse httpResponse = requestProcessor.process(httpRequest);
+
+        assertThat(httpResponse.statusCode(), is(OK));
+    }
+
+    @Test
+    public void bogusRequestAtRouteTextFile() {
+        HttpRequest httpRequest = anHttpRequestBuilder()
+                .withRequestUri("/text-file.txt")
+                .withRequestLine(POST.name())
                 .build();
 
         HttpResponse httpResponse = requestProcessor.process(httpRequest);

--- a/src/test/java/server/actions/DeleteResourceTest.java
+++ b/src/test/java/server/actions/DeleteResourceTest.java
@@ -1,0 +1,30 @@
+package server.actions;
+
+import org.junit.Test;
+import server.ResourceHandlerSpy;
+import server.StatusCode;
+import server.messages.HttpRequest;
+import server.messages.HttpResponse;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static server.HttpMethods.DELETE;
+import static server.messages.HttpRequestBuilder.anHttpRequestBuilder;
+
+public class DeleteResourceTest {
+    private ResourceHandlerSpy resourceHandlerSpy = new ResourceHandlerSpy();
+    private DeleteResource deleteResource = new DeleteResource(resourceHandlerSpy);
+
+    @Test
+    public void deleteRequestRemovesResource() {
+        HttpRequest httpRequest = anHttpRequestBuilder()
+                .withRequestUri("/form")
+                .withRequestLine(DELETE.name())
+                .build();
+
+        HttpResponse httpResponse = deleteResource.process(httpRequest);
+
+        assertThat(httpResponse.statusCode(), is(StatusCode.OK));
+        assertThat(resourceHandlerSpy.hasDeletedResource(), is(true));
+    }
+}

--- a/src/test/java/server/actions/MethodNotAllowedTest.java
+++ b/src/test/java/server/actions/MethodNotAllowedTest.java
@@ -6,15 +6,17 @@ import server.StatusCode;
 import server.messages.HttpRequest;
 import server.messages.HttpResponse;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static server.messages.HttpRequestBuilder.anHttpRequestBuilder;
 
 public class MethodNotAllowedTest {
 
+   private MethodNotAllowed methodNotAllowed =  new MethodNotAllowed();
+
     @Test
     public void statusCode405Returned() {
-        MethodNotAllowed methodNotAllowed = new MethodNotAllowed();
         HttpRequest httpRequest = anHttpRequestBuilder()
                 .withRequestLine(HttpMethods.PUT.name())
                 .build();
@@ -22,5 +24,16 @@ public class MethodNotAllowedTest {
         HttpResponse httpResponse = methodNotAllowed.process(httpRequest);
 
         assertThat(httpResponse.statusCode(), is(StatusCode.METHOD_NOT_ALLOWED));
+    }
+
+    @Test
+    public void allowMethodsAreIncludedOnResponse() {
+        HttpRequest httpRequest = anHttpRequestBuilder()
+                .withRequestLine(HttpMethods.PUT.name())
+                .build();
+
+        HttpResponse httpResponse = methodNotAllowed.process(httpRequest);
+
+        assertThat(httpResponse.allowedMethods(), containsInAnyOrder(HttpMethods.values()));
     }
 }

--- a/src/test/java/server/actions/MethodNotAllowedTest.java
+++ b/src/test/java/server/actions/MethodNotAllowedTest.java
@@ -1,0 +1,26 @@
+package server.actions;
+
+import org.junit.Test;
+import server.HttpMethods;
+import server.StatusCode;
+import server.messages.HttpRequest;
+import server.messages.HttpResponse;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static server.messages.HttpRequestBuilder.anHttpRequestBuilder;
+
+public class MethodNotAllowedTest {
+
+    @Test
+    public void statusCode405Returned() {
+        MethodNotAllowed methodNotAllowed = new MethodNotAllowed();
+        HttpRequest httpRequest = anHttpRequestBuilder()
+                .withRequestLine(HttpMethods.PUT.name())
+                .build();
+
+        HttpResponse httpResponse = methodNotAllowed.process(httpRequest);
+
+        assertThat(httpResponse.statusCode(), is(StatusCode.METHOD_NOT_ALLOWED));
+    }
+}

--- a/src/test/java/server/actions/MethodOptionsTest.java
+++ b/src/test/java/server/actions/MethodOptionsTest.java
@@ -1,0 +1,41 @@
+package server.actions;
+
+import org.junit.Test;
+import server.messages.HttpRequest;
+import server.messages.HttpResponse;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static server.HttpMethods.*;
+import static server.StatusCode.OK;
+import static server.messages.HttpRequestBuilder.anHttpRequestBuilder;
+
+public class MethodOptionsTest {
+    private MethodOptions methodOptions = new MethodOptions();
+
+    @Test
+    public void simpleOptionReturns200Code() {
+        HttpRequest httpRequest = anHttpRequestBuilder()
+                .withRequestUri("/method_options")
+                .withRequestLine(OPTIONS.name())
+                .build();
+
+        HttpResponse httpResponse = methodOptions.process(httpRequest);
+
+        assertThat(httpResponse.statusCode(), is(OK));
+    }
+
+    @Test
+    public void simpleOptionReturnsMethodsInAllow() {
+        HttpRequest httpRequest = anHttpRequestBuilder()
+                .withRequestUri("/method_options")
+                .withRequestLine(OPTIONS.name())
+                .build();
+
+        HttpResponse httpResponse = methodOptions.process(httpRequest);
+
+        assertThat(httpResponse.allowedMethods(), containsInAnyOrder(GET, HEAD, POST, OPTIONS, PUT, DELETE));
+    }
+
+}

--- a/src/test/java/server/actions/ReadResourceTest.java
+++ b/src/test/java/server/actions/ReadResourceTest.java
@@ -1,0 +1,32 @@
+package server.actions;
+
+import org.junit.Test;
+import server.ResourceHandlerSpy;
+import server.messages.HttpRequest;
+import server.messages.HttpResponse;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static server.HttpMethods.GET;
+import static server.StatusCode.OK;
+import static server.messages.HttpRequestBuilder.anHttpRequestBuilder;
+
+public class ReadResourceTest {
+    private ResourceHandlerSpy resourceHandlerSpy = new ResourceHandlerSpy();
+    private ReadResource readResource = new ReadResource(resourceHandlerSpy);
+
+    @Test
+    public void getMethodLooksUpResourceForResponseBody() {
+        HttpRequest httpRequest = anHttpRequestBuilder()
+                .withRequestUri("/form")
+                .withRequestLine(GET.name())
+                .build();
+
+        HttpResponse httpResponse = readResource.process(httpRequest);
+
+        assertThat(httpResponse.statusCode(), is(OK));
+        assertThat(httpResponse.body(), is("My=Data".getBytes()));
+        assertThat(resourceHandlerSpy.hasReadResource(), is(true));
+    }
+
+}

--- a/src/test/java/server/actions/RedirectTest.java
+++ b/src/test/java/server/actions/RedirectTest.java
@@ -1,0 +1,28 @@
+package server.actions;
+
+import org.junit.Test;
+import server.messages.HttpRequest;
+import server.messages.HttpResponse;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static server.HttpMethods.GET;
+import static server.StatusCode.FOUND;
+import static server.messages.HttpRequestBuilder.anHttpRequestBuilder;
+
+public class RedirectTest {
+    private Redirect redirect = new Redirect();
+
+    @Test
+    public void redirectReturns302() {
+        HttpRequest httpRequest = anHttpRequestBuilder()
+                .withRequestUri("/redirect")
+                .withRequestLine(GET.name())
+                .build();
+
+        HttpResponse httpResponse = redirect.process(httpRequest);
+
+        assertThat(httpResponse.statusCode(), is(FOUND));
+        assertThat(httpResponse.location(), is("http://localhost:5000/"));
+    }
+}

--- a/src/test/java/server/actions/UnknownRouteTest.java
+++ b/src/test/java/server/actions/UnknownRouteTest.java
@@ -1,0 +1,28 @@
+package server.actions;
+
+import org.junit.Test;
+import server.messages.HttpRequest;
+import server.messages.HttpResponse;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static server.HttpMethods.GET;
+import static server.StatusCode.NOT_FOUND;
+import static server.messages.HttpRequestBuilder.anHttpRequestBuilder;
+
+public class UnknownRouteTest {
+    private UnknownRoute unknownRoute = new UnknownRoute();
+
+    @Test
+    public void provides404WhenNoRoutesMet() {
+        HttpRequest httpRequest = anHttpRequestBuilder()
+                .withRequestUri("/unknown/route")
+                .withRequestLine(GET.name())
+                .build();
+
+        HttpResponse httpResponse = unknownRoute.process(httpRequest);
+
+        assertThat(httpResponse.statusCode(), is(NOT_FOUND));
+    }
+
+}

--- a/src/test/java/server/actions/WriteResourceTest.java
+++ b/src/test/java/server/actions/WriteResourceTest.java
@@ -1,0 +1,32 @@
+package server.actions;
+
+import org.junit.Test;
+import server.ResourceHandlerSpy;
+import server.messages.HttpRequest;
+import server.messages.HttpResponse;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static server.HttpMethods.POST;
+import static server.StatusCode.OK;
+import static server.messages.HttpRequestBuilder.anHttpRequestBuilder;
+
+public class WriteResourceTest {
+    private ResourceHandlerSpy resourceHandlerSpy = new ResourceHandlerSpy();
+    private WriteResource writeResource = new WriteResource(resourceHandlerSpy);
+
+    @Test
+    public void postMethodCreatesAResource() {
+        HttpRequest httpRequest = anHttpRequestBuilder()
+                .withRequestUri("/form")
+                .withBody("content")
+                .withRequestLine(POST.name())
+                .build();
+
+        HttpResponse httpResponse = writeResource.process(httpRequest);
+
+        assertThat(httpResponse.statusCode(), is(OK));
+        assertThat(httpResponse.body(), is("content".getBytes()));
+        assertThat(resourceHandlerSpy.hasWrittenToResource(), is(true));
+    }
+}


### PR DESCRIPTION
@jsuchy @ecomba @christophgockel 
This PR implements the functionality for the MethodNotAllowed Test case.

If an unknown HttpMethod is received on the incoming request, then the response code is 402. 
If certain operations are request on 'read-only' resources, then the response code is 402.

The spec states that when a 402 response is created, it should also include the Allow: headers. So they have been added also.

I also moved the test cases from the routing tests into individual tests for each routing Action, so that I could name the test cases in the router better.
