### PR TITLE
Decodes parameters on receipt of request and adds the parameters to the response body

### DIFF
--- a/src/main/java/server/HttpRouteProcessor.java
+++ b/src/main/java/server/HttpRouteProcessor.java
@@ -33,6 +33,7 @@ public class HttpRouteProcessor implements RouteProcessor {
         routes.put(new RoutingCriteria("/file1", PUT.name()), new MethodNotAllowed());
         routes.put(new RoutingCriteria("/text-file.txt", GET.name()), new ReadResource(resourceHandler));
         routes.put(new RoutingCriteria("/text-file.txt", POST.name()), new MethodNotAllowed());
+        routes.put(new RoutingCriteria("/parameters", GET.name()), new IncludeParametersInBody());
     }
 
     @Override

--- a/src/main/java/server/actions/IncludeParametersInBody.java
+++ b/src/main/java/server/actions/IncludeParametersInBody.java
@@ -1,0 +1,35 @@
+package server.actions;
+
+import server.Action;
+import server.StatusCode;
+import server.messages.HttpRequest;
+import server.messages.HttpResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static server.messages.HttpResponseBuilder.anHttpResponseBuilder;
+
+public class IncludeParametersInBody implements Action {
+    @Override
+    public HttpResponse process(HttpRequest request) {
+        String commaSeparatedListOfParameters = new FormatListAsCommaDelimitedContent<String>()
+                .commaDelimitAllowParameters(getParametersFrom(request));
+
+        return anHttpResponseBuilder()
+                .withStatusCode(StatusCode.OK)
+                .withBody(commaSeparatedListOfParameters.getBytes())
+                .build();
+    }
+
+    private List<String> getParametersFrom(HttpRequest request) {
+        List<String> parameters = new ArrayList<>();
+        Map<String, String> requestParameters = request.params();
+        parameters.addAll(requestParameters.entrySet().stream()
+                .map(entry -> entry.getKey() + " = " + entry.getValue())
+                .collect(Collectors.toList()));
+        return parameters;
+    }
+}

--- a/src/main/java/server/messages/HttpRequest.java
+++ b/src/main/java/server/messages/HttpRequest.java
@@ -5,16 +5,19 @@ import java.util.Map;
 public class HttpRequest {
 
     private final String method;
-    private String requestUri;
-    private Map<String, String> headerParams;
-    private String body;
+    private final Map<String, String> requestParams;
+    private final String requestUri;
+    private final Map<String, String> headerParams;
+    private final String body;
 
     protected HttpRequest(String method,
-                       String requestUri,
-                       Map<String, String> headerParams,
-                       String bodyContent) {
+                          String requestUri,
+                          Map<String, String> requestParams,
+                          Map<String, String> headerParams,
+                          String bodyContent) {
         this.method = method;
         this.requestUri = requestUri;
+        this.requestParams = requestParams;
         this.headerParams = headerParams;
         this.body = bodyContent;
     }
@@ -33,6 +36,10 @@ public class HttpRequest {
 
     public Map<String, String> headerParameters() {
         return headerParams;
+    }
+
+    public Map<String, String> params() {
+        return requestParams;
     }
 }
 

--- a/src/main/java/server/messages/HttpRequestBuilder.java
+++ b/src/main/java/server/messages/HttpRequestBuilder.java
@@ -6,6 +6,7 @@ public class HttpRequestBuilder {
 
     private String requestLine;
     private String requestUri;
+    private Map<String, String> requestParams;
     private Map<String, String> headerParameters;
     private String body;
 
@@ -33,7 +34,12 @@ public class HttpRequestBuilder {
         return this;
     }
 
+    public HttpRequestBuilder withParameters(Map<String, String> requestParams) {
+        this.requestParams = requestParams;
+        return this;
+    }
+
     public HttpRequest build() {
-       return new HttpRequest(requestLine, requestUri, headerParameters, body);
+       return new HttpRequest(requestLine, requestUri, requestParams, headerParameters, body);
     }
 }

--- a/src/test/java/server/HttpRouteProcessorTest.java
+++ b/src/test/java/server/HttpRouteProcessorTest.java
@@ -5,6 +5,9 @@ import org.junit.Test;
 import server.messages.HttpRequest;
 import server.messages.HttpResponse;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -233,5 +236,22 @@ public class HttpRouteProcessorTest {
         HttpResponse httpResponse = requestProcessor.process(httpRequest);
 
         assertThat(httpResponse.statusCode(), is(METHOD_NOT_ALLOWED));
+    }
+
+    @Test
+    public void routesParameters() {
+        Map<String, String> decodedParams = new HashMap<>();
+        decodedParams.put("paramKey", "paramValue");
+        decodedParams.put("anotherParamKey", "anotherParamValue");
+        HttpRequest httpRequest = anHttpRequestBuilder()
+                .withRequestUri("/parameters")
+                .withRequestLine(GET.name())
+                .withParameters(decodedParams)
+                .build();
+
+        HttpResponse httpResponse = requestProcessor.process(httpRequest);
+
+        assertThat(httpResponse.statusCode(), is(OK));
+
     }
 }

--- a/src/test/java/server/actions/IncludeParametersInBodyTest.java
+++ b/src/test/java/server/actions/IncludeParametersInBodyTest.java
@@ -1,0 +1,44 @@
+package server.actions;
+
+import org.junit.Before;
+import org.junit.Test;
+import server.StatusCode;
+import server.messages.HttpRequest;
+import server.messages.HttpRequestBuilder;
+import server.messages.HttpResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class IncludeParametersInBodyTest {
+
+    private final IncludeParametersInBody includeParametersInBody = new IncludeParametersInBody();
+    private final Map<String, String> decodedParams = new HashMap<>();
+    private HttpRequest httpRequest;
+
+    @Before
+    public void setup() {
+        decodedParams.put("key1", "value1");
+        decodedParams.put("key2", "value2");
+        httpRequest = HttpRequestBuilder.anHttpRequestBuilder()
+                .withRequestLine("GET")
+                .withRequestUri("/parameters")
+                .withParameters(decodedParams)
+                .build();
+    }
+
+    @Test
+    public void responseHasStatus200() {
+        HttpResponse response = includeParametersInBody.process(httpRequest);
+        assertThat(response.statusCode(), is(StatusCode.OK));
+    }
+
+    @Test
+    public void responseBodyContainsParameters() {
+        HttpResponse response = includeParametersInBody.process(httpRequest);
+        assertThat(response.body(), is("key1 = value1,key2 = value2".getBytes()));
+    }
+}


### PR DESCRIPTION
@jsuchy @ecomba @christophgockel

This pull request implements the ParameterDecode test case.
On receipt of the raw http message from the client, the parser extracts out the route, and the parameters, which it decodes, and creates a HttpRequest object, which is used in the rest of the system.

The routing logic then orchestrates the already decoded parameters being put into the body of the http request.
