### PR TITLE
Refactorings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 HTTP Server adhering to the Http Cob Spec
 
 [![Build Status](https://travis-ci.org/gemcfadyen/Apprenticeship-HttpServer.svg?branch=master)](https://travis-ci.org/gemcfadyen/Apprenticeship-HttpServer)    [![Coverage Status](https://coveralls.io/repos/github/gemcfadyen/Apprenticeship-HttpServer/badge.svg?branch=master)](https://coveralls.io/github/gemcfadyen/Apprenticeship-HttpServer?branch=master)
+
+
+## Setup this Http Server
+
 # Clone the project
 `git clone git@github.com:gemcfadyen/Apprenticeship-HttpServer.git`
 
@@ -10,3 +14,15 @@ HTTP Server adhering to the Http Cob Spec
 
 # build using gradle
 `./gradlew build`
+
+
+## Setup the Acceptance tests which run against this server
+
+# Navigate to your {home.directory}/Documents
+
+# Create a a folder named Projects/cob-server and clone the cob_spec repository there
+git clone git@github.com:8thlight/cob_spec.git
+
+# Follow the instructions to setup the [cob_spec Fitnesse tests on the 8th Light group](https://github.com/8thlight/cob_spec)
+
+

--- a/src/main/java/server/CommandLineArgumentParser.java
+++ b/src/main/java/server/CommandLineArgumentParser.java
@@ -4,7 +4,11 @@ import java.util.Arrays;
 
 public class CommandLineArgumentParser {
     private static final int DEFAULT_PORT = 5000;
-    private static final String DEFAULT_PUBLIC_DIRECTORY = System.getProperty("user.home") + "/Documents/Projects/cob-server/cob_spec/public";
+    private static String DEFAULT_PUBLIC_DIRECTORY;
+
+    public CommandLineArgumentParser(String homeDirectory) {
+        DEFAULT_PUBLIC_DIRECTORY = homeDirectory + "/Documents/Projects/cob-server/cob_spec/public";
+    }
 
     public int extractPort(String... commandLineArgs) {
         int indexOfPortFlag = Arrays.asList(commandLineArgs).indexOf("-p");

--- a/src/main/java/server/CommandLineArgumentParser.java
+++ b/src/main/java/server/CommandLineArgumentParser.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 
 public class CommandLineArgumentParser {
     private static final int DEFAULT_PORT = 5000;
-    private static final String DEFAULT_PUBLIC_DIRECTORY = "/Users/Georgina/Documents/Projects/cob-server/cob_spec/public";
+    private static final String DEFAULT_PUBLIC_DIRECTORY = System.getProperty("user.home") + "/Documents/Projects/cob-server/cob_spec/public";
 
     public int extractPort(String... commandLineArgs) {
         int indexOfPortFlag = Arrays.asList(commandLineArgs).indexOf("-p");
@@ -42,5 +42,4 @@ public class CommandLineArgumentParser {
     private boolean parameterKeyIsfound(int indexOfPublicDirectoryFlag) {
         return indexOfPublicDirectoryFlag != -1;
     }
-
 }

--- a/src/main/java/server/DelimitedFormatter.java
+++ b/src/main/java/server/DelimitedFormatter.java
@@ -1,19 +1,21 @@
-package server.actions;
+package server;
 
 import java.util.List;
 
-public class FormatListAsCommaDelimitedContent<T> {
+public class DelimitedFormatter<T> {
 
-   public String commaDelimitAllowParameters(List<T> values) {
+    public String delimitedValues(List<T> values, Delimiter delimiter) {
         String commaSeparatedValues = "";
         T firstValue;
         if (values.size() > 0) {
             firstValue = values.get(0);
             for (int i = 1; i < values.size(); i++) {
-                commaSeparatedValues += "," + values.get(i);
+                commaSeparatedValues += delimiter.get() + values.get(i);
             }
             return firstValue + commaSeparatedValues;
         }
         return commaSeparatedValues;
     }
 }
+
+

--- a/src/main/java/server/Delimiter.java
+++ b/src/main/java/server/Delimiter.java
@@ -1,0 +1,16 @@
+package server;
+
+public enum Delimiter {
+    COMMA(","), BREAK("<br>");
+
+    private String delimiter;
+
+    Delimiter(String delimiter) {
+        this.delimiter = delimiter;
+    }
+
+    public String get() {
+        return delimiter;
+    }
+
+}

--- a/src/main/java/server/HttpRouteProcessor.java
+++ b/src/main/java/server/HttpRouteProcessor.java
@@ -19,32 +19,31 @@ public class HttpRouteProcessor implements RouteProcessor {
     }
 
     private void configureRoutes() {
-        routes.put(new RoutingCriteria("/", GET.name()), new ListResourcesInPublicDirectory(resourceHandler));
-        routes.put(new RoutingCriteria("/form", GET.name()), new ReadResource(resourceHandler));
-        routes.put(new RoutingCriteria("/form", POST.name()), new WriteResource(resourceHandler));
-        routes.put(new RoutingCriteria("/form", PUT.name()), new WriteResource(resourceHandler));
-        routes.put(new RoutingCriteria("/form", DELETE.name()), new DeleteResource(resourceHandler));
-        routes.put(new RoutingCriteria("/method_options", OPTIONS.name()), new MethodOptions());
-        routes.put(new RoutingCriteria("/redirect", GET.name()), new Redirect());
-        routes.put(new RoutingCriteria("/image.jpeg", GET.name()), new ReadResource(resourceHandler));
-        routes.put(new RoutingCriteria("/image.png", GET.name()), new ReadResource(resourceHandler));
-        routes.put(new RoutingCriteria("/image.gif", GET.name()), new ReadResource(resourceHandler));
-        routes.put(new RoutingCriteria("/file1", GET.name()), new ReadResource(resourceHandler));
-        routes.put(new RoutingCriteria("/file1", PUT.name()), new MethodNotAllowed());
-        routes.put(new RoutingCriteria("/text-file.txt", GET.name()), new ReadResource(resourceHandler));
-        routes.put(new RoutingCriteria("/text-file.txt", POST.name()), new MethodNotAllowed());
-        routes.put(new RoutingCriteria("/parameters", GET.name()), new IncludeParametersInBody());
+        routes.put(new RoutingCriteria("/", GET), new ListResourcesInPublicDirectory(resourceHandler));
+        routes.put(new RoutingCriteria("/form", GET), new ReadResource(resourceHandler));
+        routes.put(new RoutingCriteria("/form", POST), new WriteResource(resourceHandler));
+        routes.put(new RoutingCriteria("/form", PUT), new WriteResource(resourceHandler));
+        routes.put(new RoutingCriteria("/form", DELETE), new DeleteResource(resourceHandler));
+        routes.put(new RoutingCriteria("/method_options", OPTIONS), new MethodOptions());
+        routes.put(new RoutingCriteria("/redirect", GET), new Redirect());
+        routes.put(new RoutingCriteria("/image.jpeg", GET), new ReadResource(resourceHandler));
+        routes.put(new RoutingCriteria("/image.png", GET), new ReadResource(resourceHandler));
+        routes.put(new RoutingCriteria("/image.gif", GET), new ReadResource(resourceHandler));
+        routes.put(new RoutingCriteria("/file1", GET), new ReadResource(resourceHandler));
+        routes.put(new RoutingCriteria("/file1", PUT), new MethodNotAllowed());
+        routes.put(new RoutingCriteria("/text-file.txt", GET), new ReadResource(resourceHandler));
+        routes.put(new RoutingCriteria("/text-file.txt", POST), new MethodNotAllowed());
+        routes.put(new RoutingCriteria("/parameters", GET), new IncludeParametersInBody());
     }
 
     @Override
     public HttpResponse process(HttpRequest httpRequest) {
         System.out.println("Routing key is: " + httpRequest.getRequestUri() + httpRequest.getMethod());
-        RoutingCriteria routingCriteria = new RoutingCriteria(httpRequest.getRequestUri(), httpRequest.getMethod());
 
-        if (routes.get(routingCriteria) != null) {
-            return routes.get(routingCriteria).process(httpRequest);
-        } else if (isBogusMethod(httpRequest)) {
+        if (isBogusMethod(httpRequest)) {
             return new MethodNotAllowed().process(httpRequest);
+        } else if (supportedRoute(httpRequest)) {
+            return routes.get(routingCriteria(httpRequest)).process(httpRequest);
         } else {
             return new UnknownRoute().process(httpRequest);
         }
@@ -53,6 +52,14 @@ public class HttpRouteProcessor implements RouteProcessor {
     private boolean isBogusMethod(HttpRequest httpRequest) {
         return isBogus(httpRequest.getMethod());
 
+    }
+
+    private RoutingCriteria routingCriteria(HttpRequest httpRequest) {
+        return new RoutingCriteria(httpRequest.getRequestUri(), HttpMethods.valueOf(httpRequest.getMethod()));
+    }
+
+    private boolean supportedRoute(HttpRequest httpRequest) {
+        return routes.get(routingCriteria(httpRequest)) != null;
     }
 }
 

--- a/src/main/java/server/HttpServerRunner.java
+++ b/src/main/java/server/HttpServerRunner.java
@@ -9,7 +9,7 @@ import java.net.ServerSocket;
 public class HttpServerRunner {
 
     public static void main(String... args) throws IOException {
-        CommandLineArgumentParser commandLineArgumentParser = new CommandLineArgumentParser();
+        CommandLineArgumentParser commandLineArgumentParser = new CommandLineArgumentParser(System.getProperty("user.home"));
 
         String host = "localhost";
         int port = commandLineArgumentParser.extractPort(args);

--- a/src/main/java/server/RoutingCriteria.java
+++ b/src/main/java/server/RoutingCriteria.java
@@ -2,9 +2,9 @@ package server;
 
 class RoutingCriteria {
     private final String route;
-    private final String method;
+    private final HttpMethods method;
 
-    public RoutingCriteria(String route, String method) {
+    public RoutingCriteria(String route, HttpMethods method) {
         this.route = route;
         this.method = method;
     }

--- a/src/main/java/server/actions/IncludeParametersInBody.java
+++ b/src/main/java/server/actions/IncludeParametersInBody.java
@@ -1,6 +1,7 @@
 package server.actions;
 
 import server.Action;
+import server.DelimitedFormatter;
 import server.StatusCode;
 import server.messages.HttpRequest;
 import server.messages.HttpResponse;
@@ -10,13 +11,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static server.Delimiter.COMMA;
 import static server.messages.HttpResponseBuilder.anHttpResponseBuilder;
 
 public class IncludeParametersInBody implements Action {
+    private DelimitedFormatter<String> delimitedFormatter = new DelimitedFormatter<>();
+
     @Override
     public HttpResponse process(HttpRequest request) {
-        String commaSeparatedListOfParameters = new FormatListAsCommaDelimitedContent<String>()
-                .commaDelimitAllowParameters(getParametersFrom(request));
+        String commaSeparatedListOfParameters =
+                delimitedFormatter.delimitedValues(getParametersFrom(request), COMMA);
 
         return anHttpResponseBuilder()
                 .withStatusCode(StatusCode.OK)

--- a/src/main/java/server/actions/ListResourcesInPublicDirectory.java
+++ b/src/main/java/server/actions/ListResourcesInPublicDirectory.java
@@ -1,6 +1,7 @@
 package server.actions;
 
 import server.Action;
+import server.DelimitedFormatter;
 import server.ResourceHandler;
 import server.StatusCode;
 import server.messages.HttpRequest;
@@ -11,25 +12,28 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static server.Delimiter.BREAK;
+
 public class ListResourcesInPublicDirectory implements Action {
     private ResourceHandler resourceHandler;
+    private final DelimitedFormatter listFormatter;
 
     public ListResourcesInPublicDirectory(ResourceHandler resourceHandler) {
         this.resourceHandler = resourceHandler;
+        listFormatter = new DelimitedFormatter<String>();
     }
 
     public HttpResponse process(HttpRequest request) {
         return HttpResponseBuilder
                 .anHttpResponseBuilder()
                 .withStatusCode(StatusCode.OK)
-                .withBody(getCommaSeparatedContentsOfDirectory().getBytes())
+                .withBody(getDelimitedContentsOfDirectory().getBytes())
                 .build();
     }
 
-    private String getCommaSeparatedContentsOfDirectory() {
+    private String getDelimitedContentsOfDirectory() {
         String[] filenames = resourceHandler.directoryContent();
-        FormatListAsCommaDelimitedContent listFormatter = new FormatListAsCommaDelimitedContent<String>();
-        return listFormatter.commaDelimitAllowParameters(Arrays.asList(transformToLinks(filenames)));
+        return listFormatter.delimitedValues(Arrays.asList(transformToLinks(filenames)), BREAK);
     }
 
     private String[] transformToLinks(String[] filenames) {

--- a/src/main/java/server/messages/HttpResponseFormatter.java
+++ b/src/main/java/server/messages/HttpResponseFormatter.java
@@ -1,13 +1,18 @@
 package server.messages;
 
+import server.DelimitedFormatter;
 import server.HttpMethods;
 import server.ResponseFormatter;
-import server.actions.FormatListAsCommaDelimitedContent;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 
+import static server.Delimiter.COMMA;
+
 public class HttpResponseFormatter implements ResponseFormatter {
+
+    private DelimitedFormatter listFormatter = new DelimitedFormatter<HttpMethods>();
+
     @Override
     public byte[] format(HttpResponse response) {
         try {
@@ -58,8 +63,7 @@ public class HttpResponseFormatter implements ResponseFormatter {
     }
 
     private String addAllowLineToHeader(HttpResponse response) {
-        FormatListAsCommaDelimitedContent listFormatter = new FormatListAsCommaDelimitedContent<HttpMethods>();
-        return endOfLine() + "Allow: " + listFormatter.commaDelimitAllowParameters(response.allowedMethods());
+        return endOfLine() + "Allow: " + listFormatter.delimitedValues(response.allowedMethods(), COMMA);
     }
 
     private boolean hasLocation(HttpResponse response) {

--- a/src/test/java/server/CommandLineArgumentParserTest.java
+++ b/src/test/java/server/CommandLineArgumentParserTest.java
@@ -7,9 +7,10 @@ import static org.junit.Assert.assertThat;
 
 public class CommandLineArgumentParserTest {
 
+    private final CommandLineArgumentParser commandLineArgumentParser = new CommandLineArgumentParser("homeDir");
+
     @Test
     public void portParameter() {
-        CommandLineArgumentParser commandLineArgumentParser = new CommandLineArgumentParser();
         String[] commandLineArguments = new String[]{"-p", "8080"};
         int port = commandLineArgumentParser.extractPort(commandLineArguments);
 
@@ -18,7 +19,6 @@ public class CommandLineArgumentParserTest {
 
     @Test
     public void defaultsPortTo5000IfInvalidValueProvided() {
-        CommandLineArgumentParser commandLineArgumentParser = new CommandLineArgumentParser();
         String commandLineArguments = "-p banana";
         int port = commandLineArgumentParser.extractPort(commandLineArguments);
 
@@ -27,7 +27,6 @@ public class CommandLineArgumentParserTest {
 
     @Test
     public void defaultHostIsSetTo5000() {
-        CommandLineArgumentParser commandLineArgumentParser = new CommandLineArgumentParser();
         String[] commandLineArguments = new String[]{};
         int port = commandLineArgumentParser.extractPort(commandLineArguments);
 
@@ -36,7 +35,6 @@ public class CommandLineArgumentParserTest {
 
     @Test
     public void publicDirectoryParameter() {
-        CommandLineArgumentParser commandLineArgumentParser = new CommandLineArgumentParser();
         String[] commandLineArguments = new String[]{"-d", "/some/path/here"};
         String publicDirectory = commandLineArgumentParser.extractPublicDirectory(commandLineArguments);
 
@@ -45,10 +43,9 @@ public class CommandLineArgumentParserTest {
 
     @Test
     public void publicDirectoryDefaultsWhenNotSpecified() {
-        CommandLineArgumentParser commandLineArgumentParser = new CommandLineArgumentParser();
         String[] commandLineArguments = new String[]{};
         String publicDirectory = commandLineArgumentParser.extractPublicDirectory(commandLineArguments);
 
-        assertThat(publicDirectory, is("/Users/Georgina/Documents/Projects/cob-server/cob_spec/public"));
+        assertThat(publicDirectory, is("homeDir/Documents/Projects/cob-server/cob_spec/public"));
     }
 }

--- a/src/test/java/server/RoutingCriteriaTest.java
+++ b/src/test/java/server/RoutingCriteriaTest.java
@@ -4,13 +4,15 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
+import static server.HttpMethods.GET;
+import static server.HttpMethods.POST;
 
 public class RoutingCriteriaTest {
 
     @Test
     public void routingKeysAreEqual() {
-        RoutingCriteria routingKey1 = new RoutingCriteria("/", "GET");
-        RoutingCriteria routingKey2 = new RoutingCriteria("/", "GET");
+        RoutingCriteria routingKey1 = new RoutingCriteria("/", GET);
+        RoutingCriteria routingKey2 = new RoutingCriteria("/", GET);
 
         assertThat(routingKey1, is(equalTo(routingKey2)));
         assertThat(routingKey1.hashCode(), is(equalTo(routingKey2.hashCode())));
@@ -18,8 +20,8 @@ public class RoutingCriteriaTest {
 
     @Test
     public void routeKeysWithDifferentMethodsNotEqual() {
-        RoutingCriteria routingKey1 = new RoutingCriteria("/", "GET");
-        RoutingCriteria routingKey2 = new RoutingCriteria("/", "POST");
+        RoutingCriteria routingKey1 = new RoutingCriteria("/", GET);
+        RoutingCriteria routingKey2 = new RoutingCriteria("/", POST);
 
         assertThat(routingKey1, not(equalTo(routingKey2)));
         assertThat(routingKey1.hashCode(), not(equalTo(routingKey2.hashCode())));
@@ -27,8 +29,8 @@ public class RoutingCriteriaTest {
 
     @Test
     public void routeKeysWithDifferentRoutesAreNotEqual() {
-        RoutingCriteria routingKey1 = new RoutingCriteria("/another", "GET");
-        RoutingCriteria routingKey2 = new RoutingCriteria("/", "GET");
+        RoutingCriteria routingKey1 = new RoutingCriteria("/another", GET);
+        RoutingCriteria routingKey2 = new RoutingCriteria("/", GET);
 
         assertThat(routingKey1, not(equalTo(routingKey2)));
         assertThat(routingKey1.hashCode(), not(equalTo(routingKey2.hashCode())));

--- a/src/test/java/server/actions/ListResourcesInPublicDirectoryTest.java
+++ b/src/test/java/server/actions/ListResourcesInPublicDirectoryTest.java
@@ -25,7 +25,7 @@ public class ListResourcesInPublicDirectoryTest {
         HttpResponse httpResponse = listResources.process(httpRequest);
 
         assertThat(httpResponse.statusCode(), is(StatusCode.OK));
-        assertThat(httpResponse.body(), is("<a href=/file1>file1</a>,<a href=/file2>file2</a>".getBytes()));
+        assertThat(httpResponse.body(), is("<a href=/file1>file1</a><br><a href=/file2>file2</a>".getBytes()));
         assertThat(resourceHandlerSpy.hasGotDirectoryContent(), is(true));
     }
 }


### PR DESCRIPTION
@jsuchy @ecomba @christophgockel 
This PR has some refactoring based on feedback:
- RoutingCriteria is updated to take a HttpMethod as a parameter, rather than the String representation.
- The path in CommandLineArgumentParser is made generic using `user.home`, and the readme updated to tell the user how to set the project up with the cob spec tests.
- List formatter updated to take a specified delimiter. This is so that the functionality for listing directories looks nicer in the browser.
